### PR TITLE
Feat [#28] onboardingbaseViewController 구현 및 프로그래스바 방식 수정

### DIFF
--- a/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
+++ b/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		0B50F9CF2B369813000C5046 /* HomeViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B50F9CE2B369813000C5046 /* HomeViewController.swift */; };
 		0B50F9D42B369815000C5046 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0B50F9D32B369815000C5046 /* Assets.xcassets */; };
 		0B50F9D72B369815000C5046 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0B50F9D52B369815000C5046 /* LaunchScreen.storyboard */; };
+		0B78174E2B4BD96D0078E925 /* OnboardingBaseViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B78174D2B4BD96D0078E925 /* OnboardingBaseViewControllers.swift */; };
+		0B7817502B4BD9F10078E925 /* OnboardingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B78174F2B4BD9F10078E925 /* OnboardingButton.swift */; };
 		0B8A89AD2B369E3B00688BA6 /* HomeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8A89AC2B369E3B00688BA6 /* HomeCell.swift */; };
 		0B8A89AF2B369E4300688BA6 /* HomeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8A89AE2B369E4300688BA6 /* HomeModel.swift */; };
 		0B8A89B12B369E4C00688BA6 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8A89B02B369E4C00688BA6 /* HomeView.swift */; };
@@ -138,7 +140,6 @@
 /* Begin PBXFileReference section */
 		0B00353F2B43D64D00DA140C /* HMHNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMHNavigationBar.swift; sourceTree = "<group>"; };
 		0B2C2D3A2B443BE90023CCFA /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
-		0B2C2D3E2B4559E10023CCFA /* OnboardingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButton.swift; sourceTree = "<group>"; };
 		0B2C2D402B4572240023CCFA /* HMHSelectButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMHSelectButton.swift; sourceTree = "<group>"; };
 		0B50F9C72B369813000C5046 /* HMH_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HMH_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B50F9CA2B369813000C5046 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -147,6 +148,8 @@
 		0B50F9D32B369815000C5046 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		0B50F9D62B369815000C5046 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		0B50F9D82B369815000C5046 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		0B78174D2B4BD96D0078E925 /* OnboardingBaseViewControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBaseViewControllers.swift; sourceTree = "<group>"; };
+		0B78174F2B4BD9F10078E925 /* OnboardingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButton.swift; sourceTree = "<group>"; };
 		0B8A89AC2B369E3B00688BA6 /* HomeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCell.swift; sourceTree = "<group>"; };
 		0B8A89AE2B369E4300688BA6 /* HomeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModel.swift; sourceTree = "<group>"; };
 		0B8A89B02B369E4C00688BA6 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -259,6 +262,7 @@
 		0B2C2D3C2B4559AE0023CCFA /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				0B78174C2B4BD9450078E925 /* ViewControllers */,
 				0B2C2D3D2B4559C90023CCFA /* Views */,
 			);
 			path = Onboarding;
@@ -267,9 +271,9 @@
 		0B2C2D3D2B4559C90023CCFA /* Views */ = {
 			isa = PBXGroup;
 			children = (
-				0B2C2D3E2B4559E10023CCFA /* OnboardingButton.swift */,
 				0BC0EBD32B494459003EF5D4 /* OnboardingSwipeView.swift */,
 				0BC0EBD12B493B6B003EF5D4 /* OnboardingProgressView.swift */,
+				0B78174F2B4BD9F10078E925 /* OnboardingButton.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -351,6 +355,14 @@
 				0B8A89A52B369DD500688BA6 /* Common */,
 			);
 			path = Presentation;
+			sourceTree = "<group>";
+		};
+		0B78174C2B4BD9450078E925 /* ViewControllers */ = {
+			isa = PBXGroup;
+			children = (
+				0B78174D2B4BD96D0078E925 /* OnboardingBaseViewControllers.swift */,
+			);
+			path = ViewControllers;
 			sourceTree = "<group>";
 		};
 		0B8A89952B369CD900688BA6 /* Extension */ = {
@@ -909,9 +921,11 @@
 				0B8A89B52B369F0100688BA6 /* B.swift in Sources */,
 				174AF49C2B447D0700450D07 /* ChallengeViewController.swift in Sources */,
 				17314F892B49A8B60089A551 /* AlertDelegate.swift in Sources */,
+				0B78174E2B4BD96D0078E925 /* OnboardingBaseViewControllers.swift in Sources */,
 				0B8A89B12B369E4C00688BA6 /* HomeView.swift in Sources */,
 				36A3D9B62B3EBBF7007EA272 /* Adjust+.swift in Sources */,
 				36A3D9BC2B3EBD2D007EA272 /* UIScreen+.swift in Sources */,
+				0B7817502B4BD9F10078E925 /* OnboardingButton.swift in Sources */,
 				0B50F9CD2B369813000C5046 /* SceneDelegate.swift in Sources */,
 				36A3D9B42B3EBBED007EA272 /* UIStackView+.swift in Sources */,
 				174AF4962B447CE700450D07 /* ChanllengeCells.swift in Sources */,

--- a/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
+++ b/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0B50F9D72B369815000C5046 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0B50F9D52B369815000C5046 /* LaunchScreen.storyboard */; };
 		0B78174E2B4BD96D0078E925 /* OnboardingBaseViewControllers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B78174D2B4BD96D0078E925 /* OnboardingBaseViewControllers.swift */; };
 		0B7817502B4BD9F10078E925 /* OnboardingButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B78174F2B4BD9F10078E925 /* OnboardingButton.swift */; };
+		0B7817522B4BE0280078E925 /* ProgressBarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B7817512B4BE0280078E925 /* ProgressBarManager.swift */; };
 		0B8A89AD2B369E3B00688BA6 /* HomeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8A89AC2B369E3B00688BA6 /* HomeCell.swift */; };
 		0B8A89AF2B369E4300688BA6 /* HomeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8A89AE2B369E4300688BA6 /* HomeModel.swift */; };
 		0B8A89B12B369E4C00688BA6 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B8A89B02B369E4C00688BA6 /* HomeView.swift */; };
@@ -150,6 +151,7 @@
 		0B50F9D82B369815000C5046 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0B78174D2B4BD96D0078E925 /* OnboardingBaseViewControllers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingBaseViewControllers.swift; sourceTree = "<group>"; };
 		0B78174F2B4BD9F10078E925 /* OnboardingButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingButton.swift; sourceTree = "<group>"; };
+		0B7817512B4BE0280078E925 /* ProgressBarManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBarManager.swift; sourceTree = "<group>"; };
 		0B8A89AC2B369E3B00688BA6 /* HomeCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeCell.swift; sourceTree = "<group>"; };
 		0B8A89AE2B369E4300688BA6 /* HomeModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeModel.swift; sourceTree = "<group>"; };
 		0B8A89B02B369E4C00688BA6 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
@@ -264,6 +266,7 @@
 			children = (
 				0B78174C2B4BD9450078E925 /* ViewControllers */,
 				0B2C2D3D2B4559C90023CCFA /* Views */,
+				0B7817512B4BE0280078E925 /* ProgressBarManager.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";
@@ -905,6 +908,7 @@
 				174AF4942B447B5500450D07 /* MyPageViewController.swift in Sources */,
 				36A3D9B82B3EBC3B007EA272 /* UILabel+.swift in Sources */,
 				0B50F9CB2B369813000C5046 /* AppDelegate.swift in Sources */,
+				0B7817522B4BE0280078E925 /* ProgressBarManager.swift in Sources */,
 				0B8A89C42B369FA000688BA6 /* F.swift in Sources */,
 				3666C8892B47110800564874 /* TotalTimePickerView.swift in Sources */,
 				174AF49A2B447CFB00450D07 /* ChanllengeViews.swift in Sources */,

--- a/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
+++ b/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
@@ -264,9 +264,9 @@
 		0B2C2D3C2B4559AE0023CCFA /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				0B7817512B4BE0280078E925 /* ProgressBarManager.swift */,
 				0B78174C2B4BD9450078E925 /* ViewControllers */,
 				0B2C2D3D2B4559C90023CCFA /* Views */,
-				0B7817512B4BE0280078E925 /* ProgressBarManager.swift */,
 			);
 			path = Onboarding;
 			sourceTree = "<group>";

--- a/HMH_iOS/HMH_iOS/Global/Literals/String/String.swift
+++ b/HMH_iOS/HMH_iOS/Global/Literals/String/String.swift
@@ -44,4 +44,13 @@ enum StringLiteral {
     enum AlertDescription {
         static let quit = "회원탈퇴 후 유저의 정보는 30일 동안 임시보관 후 영구 삭제됩니다."
     }
+    
+    enum OnboardingButton {
+        static let next = "다음"
+        static let permission = "권한 허용하러 가기"
+        static let selectApp = "앱 선택하기"
+        static let selectComplete = "선택 완료"
+        static let complete = "완료"
+        static let confirm = "확인"
+    }
 }

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ProgressBarManager.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ProgressBarManager.swift
@@ -5,7 +5,6 @@
 //  Created by Seonwoo Kim on 1/8/24.
 //
 
-import Foundation
 import UIKit
 
 class ProgressBarManager {

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ProgressBarManager.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ProgressBarManager.swift
@@ -1,0 +1,25 @@
+//
+//  ProgressBarManager.swift
+//  HMH_iOS
+//
+//  Created by Seonwoo Kim on 1/8/24.
+//
+
+import Foundation
+import UIKit
+
+class ProgressBarManager {
+    static let shared = ProgressBarManager()
+    let progressBarView = OnboardingProgressView()
+    
+    var progress: Int = 0
+    
+    func updateProgress(for viewController: UIViewController, step: Int) {
+        progressBarView.progressAmount = step
+    }
+    
+    func resetProgress() {
+        progress = 0
+        progressBarView.progressAmount = Int(progress)
+    }
+}

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ProgressBarManager.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ProgressBarManager.swift
@@ -14,7 +14,7 @@ class ProgressBarManager {
     
     var progress: Int = 0
     
-    func updateProgress(for viewController: UIViewController, step: Int) {
+    func updateProgress(step: Int) {
         progressBarView.progressAmount = step
     }
     

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewController.swift
@@ -1,8 +1,0 @@
-//
-//  OnboardingBaseViewController.swift
-//  HMH_iOS
-//
-//  Created by Seonwoo Kim on 1/8/24.
-//
-
-import Foundation

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewController.swift
@@ -1,5 +1,5 @@
 //
-//  OnboardingButton.swift
+//  OnboardingBaseViewController.swift
 //  HMH_iOS
 //
 //  Created by Seonwoo Kim on 1/8/24.

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewControllers.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewControllers.swift
@@ -1,0 +1,80 @@
+//
+//  OnboardingBaseViewController.swift
+//  HMH_iOS
+//
+//  Created by Seonwoo Kim on 1/8/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+protocol HomeViewPushDelegate: AnyObject {
+    func didTapButton()
+}
+
+class OnboardingBaseViewController: UIViewController {
+    weak var delegate: HomeViewPushDelegate?
+    
+    let navigationBar = HMHNavigationBar(leftItem: .normal, isBackButton: true, isTitleLabel: false, isPointImage: false)
+    let progressBar = OnboardingProgressView(progressAmount: 2)
+    private let nextButton = OnboardingButton(buttonStatus: .enabled, buttonText: "완료")
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
+        self.navigationController?.navigationBar.isHidden = true
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        progressBar.setProgressBar()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setUI()
+        setTarget()
+    }
+    
+    private func setUI() {
+        setHierarchy()
+        setConstraints()
+    }
+    
+    func setHierarchy() {
+        view.addSubviews(navigationBar, progressBar, nextButton)
+    }
+    func setConstraints() {
+        navigationBar.snp.makeConstraints {
+            $0.top.trailing.leading.equalToSuperview()
+            $0.height.equalTo(113)
+        }
+        
+        progressBar.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom)
+            $0.trailing.leading.equalToSuperview().inset(20)
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-21)
+            $0.leading.trailing.equalToSuperview().inset(20)
+        }
+    }
+    
+    func setTarget() {
+        nextButton.addTarget(self, action: #selector(onTapButton), for: .touchUpInside)
+    }
+    
+    @objc
+        func onTapButton() {
+            print("taptaptap")
+            self.delegate?.didTapButton()
+    }
+}
+
+
+
+
+

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewControllers.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewControllers.swift
@@ -43,11 +43,11 @@ class OnboardingBaseViewController: UIViewController {
         setConstraints()
     }
     
-    func setHierarchy() {
+    private func setHierarchy() {
         view.addSubviews(navigationBar, nextButton, progressBar)
     }
     
-    func setConstraints() {
+    private func setConstraints() {
         navigationBar.snp.makeConstraints {
             $0.top.trailing.leading.equalToSuperview()
             $0.height.equalTo(113.adjustedHeight)
@@ -64,7 +64,7 @@ class OnboardingBaseViewController: UIViewController {
         }
     }
     
-    func setTarget() {
+    private func setTarget() {
         nextButton.addTarget(self, action: #selector(onTapButton), for: .touchUpInside)
     }
     

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewControllers.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewControllers.swift
@@ -28,7 +28,7 @@ class OnboardingBaseViewController: UIViewController {
         self.navigationController?.navigationBar.isHidden = true
         setUI()
         setTarget()
-        ProgressBarManager.shared.updateProgress(for: self, step: step)
+        ProgressBarManager.shared.updateProgress(step: step)
     }
     
     override func viewDidLoad() {
@@ -45,21 +45,21 @@ class OnboardingBaseViewController: UIViewController {
     func setHierarchy() {
         view.addSubviews(navigationBar, nextButton, progressBar)
     }
-
+    
     func setConstraints() {
         navigationBar.snp.makeConstraints {
             $0.top.trailing.leading.equalToSuperview()
-            $0.height.equalTo(113)
+            $0.height.equalTo(113.adjustedHeight)
         }
         
         progressBar.snp.makeConstraints {
             $0.top.equalTo(navigationBar.snp.bottom)
-            $0.trailing.leading.equalToSuperview().inset(20)
+            $0.trailing.leading.equalToSuperview().inset(20.adjusted)
         }
         
         nextButton.snp.makeConstraints {
-            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-21)
-            $0.leading.trailing.equalToSuperview().inset(20)
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).offset(-21.adjusted)
+            $0.leading.trailing.equalToSuperview().inset(20.adjusted)
         }
     }
     
@@ -68,9 +68,8 @@ class OnboardingBaseViewController: UIViewController {
     }
     
     @objc
-        func onTapButton() {
-            print("taptaptap")
-            self.delegate?.didTapButton()
+    func onTapButton() {
+        self.delegate?.didTapButton()
     }
 }
 

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewControllers.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewControllers.swift
@@ -17,9 +17,10 @@ protocol HomeViewPushDelegate: AnyObject {
 class OnboardingBaseViewController: UIViewController {
     weak var delegate: HomeViewPushDelegate?
     
-    let navigationBar = HMHNavigationBar(leftItem: .normal, isBackButton: true, isTitleLabel: false, isPointImage: false)
+    var nextButtonText: String = StringLiteral.OnboardingButton.next
+    let navigationBar = HMHNavigationBar(leftItem: .normal, isBackButton: true, isTitleLabel: false, isPointImage: false, isBackGroundGray: false)
     let progressBar = ProgressBarManager.shared.progressBarView
-    let nextButton = OnboardingButton(buttonStatus: .enabled, buttonText: "완료")
+    lazy var nextButton = OnboardingButton(buttonStatus: .enabled, buttonText: nextButtonText)
     var step = 0
     
     override func viewWillAppear(_ animated: Bool) {

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewControllers.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/OnboardingBaseViewControllers.swift
@@ -18,18 +18,17 @@ class OnboardingBaseViewController: UIViewController {
     weak var delegate: HomeViewPushDelegate?
     
     let navigationBar = HMHNavigationBar(leftItem: .normal, isBackButton: true, isTitleLabel: false, isPointImage: false)
-    let progressBar = OnboardingProgressView(progressAmount: 2)
-    private let nextButton = OnboardingButton(buttonStatus: .enabled, buttonText: "완료")
+    let progressBar = ProgressBarManager.shared.progressBarView
+    let nextButton = OnboardingButton(buttonStatus: .enabled, buttonText: "완료")
+    var step = 0
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         self.navigationController?.interactivePopGestureRecognizer?.isEnabled = false
         self.navigationController?.navigationBar.isHidden = true
-    }
-    
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-        progressBar.setProgressBar()
+        setUI()
+        setTarget()
+        ProgressBarManager.shared.updateProgress(for: self, step: step)
     }
     
     override func viewDidLoad() {
@@ -44,8 +43,9 @@ class OnboardingBaseViewController: UIViewController {
     }
     
     func setHierarchy() {
-        view.addSubviews(navigationBar, progressBar, nextButton)
+        view.addSubviews(navigationBar, nextButton, progressBar)
     }
+
     func setConstraints() {
         navigationBar.snp.makeConstraints {
             $0.top.trailing.leading.equalToSuperview()

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/Views/OnboardingButton.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/Views/OnboardingButton.swift
@@ -5,4 +5,70 @@
 //  Created by Seonwoo Kim on 1/8/24.
 //
 
-import Foundation
+import UIKit
+
+import SnapKit
+import Then
+
+final class OnboardingButton: UIButton {
+    @frozen
+    enum OnboardingButtonType {
+        case enabled
+        case disabled
+    }
+
+    private var type: OnboardingButtonType = .disabled
+
+    private let buttonTitleLabel = UILabel().then {
+        $0.textColor = .whiteText
+        $0.font = .iosText4Semibold16
+    }
+
+    init(buttonStatus type: OnboardingButtonType, buttonText: String) {
+        super.init(frame: .zero)
+        self.type = type
+        buttonTitleLabel.text = buttonText
+
+        configureButton()
+        setUI()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setUI() {
+        setHierarchy()
+        setConstraints()
+    }
+
+    private func setHierarchy() {
+        self.addSubview(buttonTitleLabel)
+    }
+
+    private func setConstraints() {
+        self.snp.makeConstraints {
+            $0.height.equalTo(52.adjusted)
+        }
+
+        buttonTitleLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+
+    private func configureButton() {
+        self.makeCornerRound(radius: 6.adjustedHeight)
+        self.layer.cornerCurve = .continuous
+
+        switch type {
+        case .enabled:
+            self.isEnabled = true
+            self.backgroundColor = .bluePurpleButton
+
+        case .disabled:
+            self.isEnabled = false
+            self.backgroundColor = .gray5
+        }
+    }
+}
+

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/Views/OnboardingButton.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/Views/OnboardingButton.swift
@@ -57,7 +57,7 @@ final class OnboardingButton: UIButton {
     }
 
     private func configureButton() {
-        self.makeCornerRound(radius: 6.adjustedHeight)
+        self.makeCornerRound(radius: 6.adjusted)
         self.layer.cornerCurve = .continuous
 
         switch type {

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/Views/OnboardingProgressView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/Views/OnboardingProgressView.swift
@@ -48,9 +48,9 @@ final class OnboardingProgressView: UIProgressView {
     private func addProgressBar() {
         let startValue = Float(max(0, self.progressAmount - 1)) / 6.0
         let endValue = Float(self.progressAmount) / 6.0
-
+        
         self.setProgress(startValue, animated: false)
-
+        
         DispatchQueue.main.async() {
             UIView.animate(withDuration: 0.5, delay: 0, options: [.beginFromCurrentState, .allowUserInteraction], animations: { [unowned self] in
                 self.setProgress(endValue, animated: true)
@@ -61,9 +61,9 @@ final class OnboardingProgressView: UIProgressView {
     private func removeProgressBar() {
         let startValue = Float(min(6, self.progressAmount + 1)) / 6.0
         let endValue = Float(self.progressAmount) / 6.0
-
+        
         self.setProgress(startValue, animated: false)
-
+        
         DispatchQueue.main.async() {
             UIView.animate(withDuration: 0.5, delay: 0, options: [.beginFromCurrentState, .allowUserInteraction], animations: { [unowned self] in
                 self.setProgress(endValue, animated: true)

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/Views/OnboardingProgressView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/Views/OnboardingProgressView.swift
@@ -11,11 +11,18 @@ import SnapKit
 import Then
 
 final class OnboardingProgressView: UIProgressView {
-    private var progressAmount: Int = 0
+    var progressAmount: Int = 0 {
+        didSet {
+            if oldValue > progressAmount {
+                removeProgressBar()
+            } else {
+                addProgressBar()
+            }
+        }
+    }
     
-    init(progressAmount: Int) {
+    init() {
         super.init(frame: .zero)
-        self.progressAmount = progressAmount
         
         configureProgressView()
         setConstraints()
@@ -27,7 +34,7 @@ final class OnboardingProgressView: UIProgressView {
     
     private func setConstraints() {
         self.snp.makeConstraints {
-            $0.height.equalTo(4.adjustedHeight)
+            $0.height.equalTo(4.adjusted)
         }
     }
     
@@ -38,14 +45,29 @@ final class OnboardingProgressView: UIProgressView {
         }
     }
     
-    func setProgressBar() {
-        self.setProgress(Float(self.progressAmount - 1) / 6.0, animated: false)
-        
+    private func addProgressBar() {
+        let startValue = Float(max(0, self.progressAmount - 1)) / 6.0
+        let endValue = Float(self.progressAmount) / 6.0
+
+        self.setProgress(startValue, animated: false)
+
         DispatchQueue.main.async() {
             UIView.animate(withDuration: 0.5, delay: 0, options: [.beginFromCurrentState, .allowUserInteraction], animations: { [unowned self] in
-                self.setProgress(Float(self.progressAmount) / 6.0, animated: true)
+                self.setProgress(endValue, animated: true)
+            })
+        }
+    }
+    
+    private func removeProgressBar() {
+        let startValue = Float(min(6, self.progressAmount + 1)) / 6.0
+        let endValue = Float(self.progressAmount) / 6.0
+
+        self.setProgress(startValue, animated: false)
+
+        DispatchQueue.main.async() {
+            UIView.animate(withDuration: 0.5, delay: 0, options: [.beginFromCurrentState, .allowUserInteraction], animations: { [unowned self] in
+                self.setProgress(endValue, animated: true)
             })
         }
     }
 }
-


### PR DESCRIPTION
## 👾 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 온보딩에 재활용이 널리 되는 OnboardingBaseViewController를 제작하였습니다.
- 프로그래스 바를 기존 방식에서 싱글톤 방식과 같이 수정하였습니다.
- 방식 수정에 따라 ProgressBarManager 파일을 생성하여 하나로 집중 관리 합니다.
```swift
class ProgressBarManager {
    static let shared = ProgressBarManager()
    let progressBarView = OnboardingProgressView()
```
- 뷰컨트롤러에서 다음과 같이 호출하여 사용합니다.
```swift
  let progressBar = ProgressBarManager.shared.progressBarView
```
- 역방향으로 프로그래스 바가 감소하는 애니메이션도 구현하였습니다.
- didset 분기 처리에 따른 애니메이션 타입을 결정합니다.
```swift
    var progressAmount: Int = 0 {
        didSet {
            if oldValue > progressAmount {
                removeProgressBar()
            } else {
                addProgressBar()
            }
        }
    }

```
## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 뷰의 생명주기에 따라 처리를 잘해야할 것 같습니다.

## 📸 스크린샷
- 네비바 레이아웃 업데이트 전 입니다.
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 화면종류 | <img src="https://github.com/Team-HMH/HMH-iOS/assets/95562494/aa361597-878a-41fb-b620-6c9571260894" width="50%" height="50%"/>| |


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #28 
