### PR TITLE
Feat [#49] SignInCompleteViewController 회원가입 완료 화면 구현

### DIFF
--- a/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
+++ b/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		0BC0EBD42B494459003EF5D4 /* OnboardingSwipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC0EBD32B494459003EF5D4 /* OnboardingSwipeView.swift */; };
 		0BD98DB92B4D671600E35188 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD98DB82B4D671600E35188 /* SplashViewController.swift */; };
 		0BD98DBE2B4D6AB700E35188 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD98DBD2B4D6AB700E35188 /* LoginViewController.swift */; };
+		0BFD2FB42B4EE71900C6327F /* SignInCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BFD2FB32B4EE71900C6327F /* SignInCompleteViewController.swift */; };
 		17314F7F2B485E150089A551 /* CustomAlertButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17314F7E2B485E150089A551 /* CustomAlertButton.swift */; };
 		17314F832B486BEC0089A551 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17314F822B486BEC0089A551 /* AlertViewController.swift */; };
 		17314F852B497FDE0089A551 /* HMHLogoutAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17314F842B497FDE0089A551 /* HMHLogoutAlert.swift */; };
@@ -190,6 +191,7 @@
 		0BC0EBD32B494459003EF5D4 /* OnboardingSwipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSwipeView.swift; sourceTree = "<group>"; };
 		0BD98DB82B4D671600E35188 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		0BD98DBD2B4D6AB700E35188 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		0BFD2FB32B4EE71900C6327F /* SignInCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInCompleteViewController.swift; sourceTree = "<group>"; };
 		17314F7E2B485E150089A551 /* CustomAlertButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertButton.swift; sourceTree = "<group>"; };
 		17314F822B486BEC0089A551 /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
 		17314F842B497FDE0089A551 /* HMHLogoutAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMHLogoutAlert.swift; sourceTree = "<group>"; };
@@ -417,6 +419,7 @@
 				0B78174D2B4BD96D0078E925 /* OnboardingBaseViewControllers.swift */,
 				0BA193B32B4D089C007E3F9C /* TimeSurveyViewController.swift */,
 				0BA193B52B4D08B7007E3F9C /* ProblemSurveyViewController.swift */,
+				0BFD2FB32B4EE71900C6327F /* SignInCompleteViewController.swift */,
 			);
 			path = ViewControllers;
 			sourceTree = "<group>";
@@ -1050,6 +1053,7 @@
 				17314FAF2B4D3E1C0089A551 /* LogoutAndQuitFooterView.swift in Sources */,
 				0B78174E2B4BD96D0078E925 /* OnboardingBaseViewControllers.swift in Sources */,
 				0B8A89B12B369E4C00688BA6 /* HomeView.swift in Sources */,
+				0BFD2FB42B4EE71900C6327F /* SignInCompleteViewController.swift in Sources */,
 				36A3D9B62B3EBBF7007EA272 /* Adjust+.swift in Sources */,
 				36A3D9BC2B3EBD2D007EA272 /* UIScreen+.swift in Sources */,
 				0B7817502B4BD9F10078E925 /* OnboardingButton.swift in Sources */,

--- a/HMH_iOS/HMH_iOS/Global/Literals/String/String.swift
+++ b/HMH_iOS/HMH_iOS/Global/Literals/String/String.swift
@@ -79,6 +79,7 @@ enum StringLiteral {
         static let selectTotalTime = "총 목표 이용 시간을\n설정해 주세요"
         static let approvePermision = "스크린타임 권한 허용이 필요해요"
         static let appSelect = "중독에서 탈출하고 싶은\n앱을 선택해 주세요"
+        static let signInComplete = "회원가입 완료"
     }
     
     enum OnboardigSub {
@@ -87,6 +88,7 @@ enum StringLiteral {
         static let selectTotalTime = "목표 이용 시간은 최대 6시간까지 설정할 수 있어요"
         static let approvePermision = "언제든지 설정에서 스크린타임 권한을\n변경할 수 있어요"
         static let appSelect = "목표 이용 시간이 지나면 앱이 잠겨요\n선택하고 싶은 앱은 언제든지 추가할 수 있어요"
+        static let signInComplete = "이제 하면함에서 블랙홀 탈출을 위한\n여정을 시작해 볼까요?"
     }
     
     enum TimeSurveySelect {

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/SignInCompleteViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/SignInCompleteViewController.swift
@@ -11,19 +11,20 @@ import SnapKit
 import Then
 
 final class SignInCompleteViewController: OnboardingBaseViewController {
-    private let SignInMainLabel = UILabel().then {
+    
+    private let signInMainLabel = UILabel().then {
         $0.textColor = .whiteText
         $0.font = .iosTitle3Semibold22
         $0.text = StringLiteral.OnboardigMain.signInComplete
     }
-    private let SignInSubLabel = UILabel().then {
+    private let signInSubLabel = UILabel().then {
         $0.textColor = .gray2
         $0.font = .iosText6Medium14
         $0.text = StringLiteral.OnboardigSub.signInComplete
         $0.setTextWithLineHeight(text: $0.text, lineHeight: 21)
     }
     
-    private let SignInImageView = UIImageView().then {
+    private let signInImageView = UIImageView().then {
         $0.image = ImageLiterals.myPage.icBadge
         $0.contentMode = .scaleAspectFit
     }
@@ -41,24 +42,24 @@ final class SignInCompleteViewController: OnboardingBaseViewController {
     }
     
     private func setHierarchy() {
-        view.addSubviews(SignInMainLabel,SignInSubLabel,SignInImageView)
+        view.addSubviews(signInMainLabel,signInSubLabel,signInImageView)
     }
     
     private func setConstraints() {
-        SignInImageView.snp.makeConstraints {
+        signInImageView.snp.makeConstraints {
             $0.top.equalTo(navigationBar.snp.bottom).offset(126.adjustedHeight)
             $0.size.equalTo(150.adjusted)
             $0.centerX.equalToSuperview()
         }
         
-        SignInMainLabel.snp.makeConstraints {
+        signInMainLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(SignInImageView.snp.bottom).offset(27.adjustedHeight)
+            $0.top.equalTo(signInImageView.snp.bottom).offset(27.adjustedHeight)
         }
         
-        SignInSubLabel.snp.makeConstraints {
+        signInSubLabel.snp.makeConstraints {
             $0.centerX.equalToSuperview()
-            $0.top.equalTo(SignInMainLabel.snp.bottom).offset(8.adjustedHeight)
+            $0.top.equalTo(signInMainLabel.snp.bottom).offset(8.adjustedHeight)
         }
     }
     

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/SignInCompleteViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/SignInCompleteViewController.swift
@@ -1,0 +1,89 @@
+//
+//  SignInSuccessViewController.swift
+//  HMH_iOS
+//
+//  Created by Seonwoo Kim on 1/10/24.
+//
+
+import UIKit
+
+import SnapKit
+import Then
+
+final class SignInCompleteViewController: OnboardingBaseViewController {
+    private let SignInMainLabel = UILabel().then {
+        $0.textColor = .whiteText
+        $0.font = .iosTitle3Semibold22
+        $0.text = StringLiteral.OnboardigMain.signInComplete
+    }
+    private let SignInSubLabel = UILabel().then {
+        $0.textColor = .gray2
+        $0.font = .iosText6Medium14
+        $0.text = StringLiteral.OnboardigSub.signInComplete
+        $0.setTextWithLineHeight(text: $0.text, lineHeight: 21)
+    }
+    
+    private let SignInImageView = UIImageView().then {
+        $0.image = ImageLiterals.myPage.icBadge
+        $0.contentMode = .scaleAspectFit
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureBaseView()
+        setDelegate()
+        setUI()
+    }
+    
+    private func setUI() {
+        setHierarchy()
+        setConstraints()
+    }
+    
+    private func setHierarchy() {
+        view.addSubviews(SignInMainLabel,SignInSubLabel,SignInImageView)
+    }
+    
+    private func setConstraints() {
+        SignInImageView.snp.makeConstraints {
+            $0.top.equalTo(navigationBar.snp.bottom).offset(126.adjustedHeight)
+            $0.size.equalTo(150.adjusted)
+            $0.centerX.equalToSuperview()
+        }
+        
+        SignInMainLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(SignInImageView.snp.bottom).offset(27.adjustedHeight)
+        }
+        
+        SignInSubLabel.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(SignInMainLabel.snp.bottom).offset(8.adjustedHeight)
+        }
+    }
+    
+    private func setDelegate() {
+        self.delegate = self
+    }
+    
+    private func configureBaseView() {
+        view.backgroundColor = .background
+        progressBar.isHidden = true
+        nextButton.setButtonText(buttonTitle: StringLiteral.OnboardingButton.confirm)
+        nextButton.updateStatus(isEnabled: true)
+    }
+}
+
+extension SignInCompleteViewController: NextViewPushDelegate {
+    func didTapButton() {
+        let nextViewController = TabBarController()
+        let navigationController = UINavigationController(rootViewController: nextViewController)
+        let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+        guard let delegate = sceneDelegate else {
+            return
+        }
+        delegate.window?.rootViewController = navigationController
+    }
+}
+
+


### PR DESCRIPTION
## 👾 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- SignInCompleteViewController를 구현 하였습니다.
- 기존 OnboardingBaseViewController의 progressbar를 히든 처리 해서 구현 하였습니다.

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 온보딩 뷰가 마감되고 메인 탭바 컨트롤러로 이동하게 됩니다.
- 이때 네비게이션 스택에 온보딩 관련 뷰들이 남으면 안되므로 rootViewController를 바꿔주는 로직을 구현했습니다.
```swift
    func didTapButton() {
        let nextViewController = TabBarController()
        let navigationController = UINavigationController(rootViewController: nextViewController)
        let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
        guard let delegate = sceneDelegate else {
            return
        }
        delegate.window?.rootViewController = navigationController
    }
```
- 이미지는 아직 나오지 않아서 임의로 설정했습니다.

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
|회원가입 완료 | ![Simulator Screen Recording - iPhone SE (3rd generation) - 2024-01-11 at 00 57 13](https://github.com/Team-HMH/HMH-iOS/assets/95562494/07ac6524-45ab-40d2-a9b1-0d5f7a1629eb) |



## 🚀 기기 대응
|    기기명    |   Iphone 13 mini  | Iphone 14 | Iphone 15 pro | Iphone SE(3rd) |
| :-------------: | :----------: | :----------: | :----------: |:----------: |
| 스크린샷 | ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/d7ba8d6a-1cd6-461c-83ab-4d5c548ec42e) | ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/8fe69440-0a06-4022-a65a-f8a294e59bd1) | ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/0a82f529-e18c-4b2f-a954-bc2dceb177b8) | ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/b199be2b-1c31-48c3-90f9-a5fa83cc4ab2) |

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #49 
