### PR TITLE
Feat [#51] 스크린 타임 모니터링 앱 삭제 UI 로직

### DIFF
--- a/HMH_iOS/HMH_iOS/Application/SceneDelegate.swift
+++ b/HMH_iOS/HMH_iOS/Application/SceneDelegate.swift
@@ -24,7 +24,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             DispatchQueue.main.async{
-                showLoginViewController()
+                showTabBarViewController()
             }
         }
         

--- a/HMH_iOS/HMH_iOS/Global/Literals/String/String.swift
+++ b/HMH_iOS/HMH_iOS/Global/Literals/String/String.swift
@@ -22,7 +22,8 @@ enum StringLiteral {
         }
         enum AppList {
             static var appListHeaderTitle = "앱 잠금"
-            static var appListHeaderButtonText = "삭제"
+            static var appListDeleteHeaderButtonText = "삭제"
+            static var appListCancelHeaderButtonText = "취소"
         }
         enum Idetifier {
             static var titleHeaderViewId = "TitleSectionHeader"

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Cells/AppListCollectionViewCell.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Cells/AppListCollectionViewCell.swift
@@ -13,6 +13,15 @@ import Then
 final class AppListCollectionViewCell: UICollectionViewCell {
     
     static let identifer = "AppListCollectionViewCell"
+    var isSelectedCell = false {
+        didSet {
+            if isSelectedCell {
+                contentView.makeBorder(width: 1.3, color: .gray5)
+            } else {
+                contentView.makeBorder(width: 0, color: .clear)
+            }
+        }
+    }
     
     private let appImageView = UIImageView().then {
         $0.backgroundColor = .blue
@@ -38,6 +47,11 @@ final class AppListCollectionViewCell: UICollectionViewCell {
     
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        self.makeBorder(width: 0, color: .gray5)
     }
     
     override func layoutSubviews() {

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Cells/HeaderFooterView/AppCollectionReusableView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Cells/HeaderFooterView/AppCollectionReusableView.swift
@@ -14,6 +14,12 @@ final class AppCollectionReusableView: UICollectionReusableView {
     
     static let identifier = "AppCollectionReusableView"
     
+    var isDeleteMode = false {
+        didSet {
+            configureButton()
+        }
+    }
+    
     private let titleLabel = UILabel().then {
         $0.text = StringLiteral.Challenge.AppList.appListHeaderTitle
         $0.font = .iosText5Medium16
@@ -21,15 +27,11 @@ final class AppCollectionReusableView: UICollectionReusableView {
         $0.setTextWithLineHeight(text: $0.text, lineHeight: 24)
     }
     
-    let deleteButton = UIButton().then {
-        $0.setTitle(StringLiteral.Challenge.AppList.appListHeaderButtonText,
-                    for: .normal)
-        $0.titleLabel?.font = .iosText4Semibold16
-        $0.setTitleColor(.bluePurpleText, for: .normal)
-    }
+    let deleteButton = UIButton()
     
     override init(frame: CGRect) {
         super.init(frame: frame)
+        configureButton()
         setUI()
     }
     
@@ -56,4 +58,19 @@ final class AppCollectionReusableView: UICollectionReusableView {
             $0.centerY.equalTo(titleLabel.snp.centerY)
         }
     }
+    
+    private func configureButton() {
+        if isDeleteMode{
+            deleteButton.setTitle(StringLiteral.Challenge.AppList.appListCancelHeaderButtonText,
+                        for: .normal)
+            deleteButton.titleLabel?.font = .iosText4Semibold16
+            deleteButton.setTitleColor(.gray4, for: .normal)
+        } else {
+            deleteButton.setTitle(StringLiteral.Challenge.AppList.appListDeleteHeaderButtonText,
+                        for: .normal)
+            deleteButton.titleLabel?.font = .iosText4Semibold16
+            deleteButton.setTitleColor(.bluePurpleText, for: .normal)
+        }
+    }
+    
 }

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Cells/HeaderFooterView/AppCollectionReusableView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Cells/HeaderFooterView/AppCollectionReusableView.swift
@@ -21,7 +21,7 @@ final class AppCollectionReusableView: UICollectionReusableView {
         $0.setTextWithLineHeight(text: $0.text, lineHeight: 24)
     }
     
-    private let deleteButton = UIButton().then {
+    let deleteButton = UIButton().then {
         $0.setTitle(StringLiteral.Challenge.AppList.appListHeaderButtonText,
                     for: .normal)
         $0.titleLabel?.font = .iosText4Semibold16

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/ViewControllers/ChallengeViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/ViewControllers/ChallengeViewController.swift
@@ -19,6 +19,7 @@ final class ChallengeViewController: UIViewController {
                                                  isBackGroundGray: true,
                                                  titleText: StringLiteral.Challenge.NavigationBarTitle)
     private let challengeView = ChallengeView()
+    private var selectedIndex = IndexPath()
     
     override func loadView() {
         self.view = challengeView
@@ -27,6 +28,7 @@ final class ChallengeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setUI()
+        setDelegate()
     }
     
     private func setUI(){
@@ -44,4 +46,35 @@ final class ChallengeViewController: UIViewController {
         }
     }
     
+    private func setDelegate() {
+        challengeView.challengeCollectionView.delegate = self
+    }
+    
+}
+
+extension ChallengeViewController: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath) -> Bool {
+        if let selectedIndexPath = collectionView.indexPathsForSelectedItems?.first {
+            if selectedIndexPath == indexPath {
+                return false
+            }
+        }
+        return true
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        if selectedIndex == [] {
+            selectedIndex = [1,0]
+        }
+        if challengeView.isDeleteMode {
+            if let previousSelectedCell = collectionView.cellForItem(at: selectedIndex) as?  AppListCollectionViewCell {
+                previousSelectedCell.isSelectedCell = false
+            }
+            if let currentSelectedCell = collectionView.cellForItem(at: indexPath) as? AppListCollectionViewCell {
+                currentSelectedCell.isSelectedCell = true
+                self.selectedIndex = indexPath
+            }
+            
+        }
+    }
 }

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/ViewControllers/ChallengeViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/ViewControllers/ChallengeViewController.swift
@@ -49,7 +49,6 @@ final class ChallengeViewController: UIViewController {
     private func setDelegate() {
         challengeView.challengeCollectionView.delegate = self
     }
-    
 }
 
 extension ChallengeViewController: UICollectionViewDelegate {
@@ -67,7 +66,7 @@ extension ChallengeViewController: UICollectionViewDelegate {
             selectedIndex = [1,0]
         }
         if challengeView.isDeleteMode {
-            if let previousSelectedCell = collectionView.cellForItem(at: selectedIndex) as?  AppListCollectionViewCell {
+            if let previousSelectedCell = collectionView.cellForItem(at: selectedIndex) as? AppListCollectionViewCell {
                 previousSelectedCell.isSelectedCell = false
             }
             if let currentSelectedCell = collectionView.cellForItem(at: indexPath) as? AppListCollectionViewCell {

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
@@ -147,7 +147,6 @@ extension ChallengeView: UICollectionViewDataSource {
                 return header
             }
             else { return UICollectionReusableView() }
-            
         } else if kind == StringLiteral.Challenge.Idetifier.appAddFooterViewID {
             guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: StringLiteral.Challenge.Idetifier.appAddFooterViewID, withReuseIdentifier: AppAddCollectionReusableView.identifier, for: indexPath) as? AppAddCollectionReusableView
             else { return UICollectionReusableView() }

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
@@ -16,7 +16,7 @@ final class ChallengeView: UIView {
     private var days: Int = 7
     private var appList: [AppModel] = [AppModel(appIcon: "", appName: "Instagram", appUseTime: "1시간 20분"),
                                        AppModel(appIcon: "", appName: "Youtube", appUseTime: "1시간")]
-    private var isDeleteMode: Bool = false {
+    var isDeleteMode: Bool = false {
         didSet {
             challengeCollectionView.reloadData()
         }

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
@@ -83,7 +83,6 @@ final class ChallengeView: UIView {
     
     @objc private func deleteButtonTapped() {
         isDeleteMode.toggle()
-        print(isDeleteMode)
         challengeCollectionView.reloadData()
     }
 }

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
@@ -83,7 +83,6 @@ final class ChallengeView: UIView {
     
     @objc private func deleteButtonTapped() {
         isDeleteMode.toggle()
-        challengeCollectionView.reloadData()
     }
 }
 

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
@@ -80,7 +80,6 @@ final class ChallengeView: UIView {
         
     }
 }
-}
 
 extension ChallengeView: UICollectionViewDataSource {
     

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
@@ -16,6 +16,11 @@ final class ChallengeView: UIView {
     private var days: Int = 7
     private var appList: [AppModel] = [AppModel(appIcon: "", appName: "Instagram", appUseTime: "1시간 20분"),
                                        AppModel(appIcon: "", appName: "Youtube", appUseTime: "1시간")]
+    private var isDeleteMode: Bool = false {
+        didSet {
+            challengeCollectionView.reloadData()
+        }
+    }
     
     lazy var challengeCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()).then {
         $0.backgroundColor = .background
@@ -77,7 +82,9 @@ final class ChallengeView: UIView {
     }
     
     @objc private func deleteButtonTapped() {
-        
+        isDeleteMode.toggle()
+        print(isDeleteMode)
+        challengeCollectionView.reloadData()
     }
 }
 
@@ -112,6 +119,16 @@ extension ChallengeView: UICollectionViewDataSource {
                     as? AppListCollectionViewCell else {
                 return UICollectionViewCell()
             }
+            if isDeleteMode {
+                if indexPath.item == 0 {
+                    cell.isSelectedCell = true
+                }
+                else {
+                    cell.isSelectedCell = false
+                }
+            } else {
+                cell.isSelectedCell = false
+            }
             cell.configureCell(appName: appList[indexPath.item].appName, appTime: appList[indexPath.item].appUseTime)
             return cell
         default:
@@ -127,6 +144,7 @@ extension ChallengeView: UICollectionViewDataSource {
         } else if kind == StringLiteral.Challenge.Idetifier.appListHeaderViewId {
             if let header = collectionView.dequeueReusableSupplementaryView(ofKind: StringLiteral.Challenge.Idetifier.appListHeaderViewId, withReuseIdentifier: AppCollectionReusableView.identifier, for: indexPath) as? AppCollectionReusableView {
                 header.deleteButton.addTarget(self, action: #selector(deleteButtonTapped), for: .touchUpInside)
+                header.isDeleteMode = isDeleteMode
                 return header
             }
             else { return UICollectionReusableView() }

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
@@ -14,7 +14,7 @@ final class ChallengeView: UIView {
     
     private let goalTime: Int = 3
     private var days: Int = 7
-    private let appList: [AppModel] = [AppModel(appIcon: "", appName: "Instagram", appUseTime: "1시간 20분"),
+    private var appList: [AppModel] = [AppModel(appIcon: "", appName: "Instagram", appUseTime: "1시간 20분"),
                                        AppModel(appIcon: "", appName: "Youtube", appUseTime: "1시간")]
     
     lazy var challengeCollectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout()).then {
@@ -30,7 +30,6 @@ final class ChallengeView: UIView {
         setRegister()
         configureView()
         configreCollectionView()
-        addTarget()
     }
     
     required init?(coder: NSCoder) {
@@ -77,7 +76,10 @@ final class ChallengeView: UIView {
         challengeCollectionView.dataSource = self
     }
     
-    func addTarget() {}
+    @objc private func deleteButtonTapped() {
+        
+    }
+}
 }
 
 extension ChallengeView: UICollectionViewDataSource {
@@ -124,9 +126,12 @@ extension ChallengeView: UICollectionViewDataSource {
             else { return UICollectionReusableView() }
             return header
         } else if kind == StringLiteral.Challenge.Idetifier.appListHeaderViewId {
-            guard let header = collectionView.dequeueReusableSupplementaryView(ofKind: StringLiteral.Challenge.Idetifier.appListHeaderViewId, withReuseIdentifier: AppCollectionReusableView.identifier, for: indexPath) as? AppCollectionReusableView
+            if let header = collectionView.dequeueReusableSupplementaryView(ofKind: StringLiteral.Challenge.Idetifier.appListHeaderViewId, withReuseIdentifier: AppCollectionReusableView.identifier, for: indexPath) as? AppCollectionReusableView {
+                header.deleteButton.addTarget(self, action: #selector(deleteButtonTapped), for: .touchUpInside)
+                return header
+            }
             else { return UICollectionReusableView() }
-            return header
+            
         } else if kind == StringLiteral.Challenge.Idetifier.appAddFooterViewID {
             guard let footer = collectionView.dequeueReusableSupplementaryView(ofKind: StringLiteral.Challenge.Idetifier.appAddFooterViewID, withReuseIdentifier: AppAddCollectionReusableView.identifier, for: indexPath) as? AppAddCollectionReusableView
             else { return UICollectionReusableView() }


### PR DESCRIPTION
## 👾 작업 내용
- 나의 챌린지 뷰에서 삭제 버튼을 눌러서 스크린 타임을 모니터링하던 앱을 삭제하는 UI 로직입니다. 

## 🚀 PR Point
- header를 정의하면서 `addTarge`을 해주어야해서 이 경우에만 예외적으로 `addTarget` 함수를 따로 만들지 않았습니다. 
https://github.com/Team-HMH/HMH-iOS/blob/232d540978f2e985dc7c9a4b70f46555d6d38747/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift#L143-L151

- Property Observer인 didSet을 이용해서 값이 변화하는지 감지 후 `collectionView`를 `reload`해주었습니다. 
https://github.com/Team-HMH/HMH-iOS/blob/232d540978f2e985dc7c9a4b70f46555d6d38747/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift#L19-L23

- `UICollectionViewDelegate`를 사용해서 앱 목록 중 하나를 터치했을 때, 선택 되도록 구현했습니다. 
https://github.com/Team-HMH/HMH-iOS/blob/0a919ce0523de12452cf61fe66677b5009b49a93/HMH_iOS/HMH_iOS/Presentation/Challenge/ViewControllers/ChallengeViewController.swift#L65-L79

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 삭제 로직 | ![Simulator Screen Recording - iPhone 13 mini - 2024-01-11 at 06 53 45](https://github.com/Team-HMH/HMH-iOS/assets/68178395/6e0d11cc-1629-4e15-8744-638a727ad595) |

## 🚀 기기 대응
|    기기명    |   Iphone 13 mini  | Iphone 14 | Iphone 15 pro | Iphone SE(3rd) |
| :-------------: | :----------: | :----------: | :----------: |:----------: |
| 스크린샷 | ![Simulator Screenshot - iPhone 13 mini - 2024-01-11 at 06 55 01](https://github.com/Team-HMH/HMH-iOS/assets/68178395/1d6d02d3-72eb-4c55-a2db-23a9e6b13c4b) | ![image](https://github.com/Team-HMH/HMH-iOS/assets/68178395/c3bc731d-611e-4788-8612-7ca65904ae71) | ![image](https://github.com/Team-HMH/HMH-iOS/assets/68178395/816fa45c-b7a6-4080-b878-80584fca3a74) | ![image](https://github.com/Team-HMH/HMH-iOS/assets/68178395/b9f5820f-2ad0-4368-802c-c8ae6438385e) |

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #51 
