### PR TITLE
Set [#46] apple login 기초 세팅

### DIFF
--- a/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
+++ b/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		0B000CED2B4D9DA800AEC582 /* ApprovePermisionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B000CEC2B4D9DA800AEC582 /* ApprovePermisionController.swift */; };
 		0B000CF12B4DA30F00AEC582 /* AppSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B000CF02B4DA30F00AEC582 /* AppSelectViewController.swift */; };
 		0B0035402B43D64D00DA140C /* HMHNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B00353F2B43D64D00DA140C /* HMHNavigationBar.swift */; };
+		0B17D3EB2B5104E000CFA3B7 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B17D3EA2B5104E000CFA3B7 /* UserManager.swift */; };
+		0B17D3ED2B5108D200CFA3B7 /* UserDefaultWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B17D3EC2B5108D200CFA3B7 /* UserDefaultWrapper.swift */; };
 		0B2C2D3B2B443BE90023CCFA /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2C2D3A2B443BE90023CCFA /* Image.swift */; };
 		0B2C2D412B4572240023CCFA /* HMHSelectButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2C2D402B4572240023CCFA /* HMHSelectButton.swift */; };
 		0B50F9CB2B369813000C5046 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B50F9CA2B369813000C5046 /* AppDelegate.swift */; };
@@ -163,6 +165,8 @@
 		0B000CEC2B4D9DA800AEC582 /* ApprovePermisionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovePermisionController.swift; sourceTree = "<group>"; };
 		0B000CF02B4DA30F00AEC582 /* AppSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSelectViewController.swift; sourceTree = "<group>"; };
 		0B00353F2B43D64D00DA140C /* HMHNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMHNavigationBar.swift; sourceTree = "<group>"; };
+		0B17D3EA2B5104E000CFA3B7 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
+		0B17D3EC2B5108D200CFA3B7 /* UserDefaultWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultWrapper.swift; sourceTree = "<group>"; };
 		0B2C2D3A2B443BE90023CCFA /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		0B2C2D402B4572240023CCFA /* HMHSelectButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMHSelectButton.swift; sourceTree = "<group>"; };
 		0B50F9C72B369813000C5046 /* HMH_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HMH_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -308,6 +312,15 @@
 				0B000CF02B4DA30F00AEC582 /* AppSelectViewController.swift */,
 			);
 			path = ViewControllers;
+			sourceTree = "<group>";
+		};
+		0B17D3E92B5104B900CFA3B7 /* User */ = {
+			isa = PBXGroup;
+			children = (
+				0B17D3EA2B5104E000CFA3B7 /* UserManager.swift */,
+				0B17D3EC2B5108D200CFA3B7 /* UserDefaultWrapper.swift */,
+			);
+			path = User;
 			sourceTree = "<group>";
 		};
 		0B2C2D3C2B4559AE0023CCFA /* Onboarding */ = {
@@ -458,6 +471,7 @@
 		0B8A89982B369CF800688BA6 /* SupportingFiles */ = {
 			isa = PBXGroup;
 			children = (
+				0B17D3E92B5104B900CFA3B7 /* User */,
 				3666C8782B45F4D900564874 /* AppBlock */,
 				0B8A89992B369D0B00688BA6 /* Base */,
 			);
@@ -1012,6 +1026,7 @@
 				0B8A89AF2B369E4300688BA6 /* HomeModel.swift in Sources */,
 				3666C89F2B485C8F00564874 /* DateCollectionViewCell.swift in Sources */,
 				3666C87A2B45F4F900564874 /* SelectedBlocker.swift in Sources */,
+				0B17D3ED2B5108D200CFA3B7 /* UserDefaultWrapper.swift in Sources */,
 				0BC0EBD42B494459003EF5D4 /* OnboardingSwipeView.swift in Sources */,
 				17314F9B2B4C485B0089A551 /* UserPointHeaderView.swift in Sources */,
 				36A3D9C02B409CBD007EA272 /* Font.swift in Sources */,
@@ -1022,6 +1037,7 @@
 				174AF4942B447B5500450D07 /* MyPageViewController.swift in Sources */,
 				0BA193B42B4D089C007E3F9C /* TimeSurveyViewController.swift in Sources */,
 				36A3D9B82B3EBC3B007EA272 /* UILabel+.swift in Sources */,
+				0B17D3EB2B5104E000CFA3B7 /* UserManager.swift in Sources */,
 				0B50F9CB2B369813000C5046 /* AppDelegate.swift in Sources */,
 				0B7817522B4BE0280078E925 /* ProgressBarManager.swift in Sources */,
 				0B8A89C42B369FA000688BA6 /* F.swift in Sources */,

--- a/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
+++ b/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		0B000CED2B4D9DA800AEC582 /* ApprovePermisionController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B000CEC2B4D9DA800AEC582 /* ApprovePermisionController.swift */; };
 		0B000CF12B4DA30F00AEC582 /* AppSelectViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B000CF02B4DA30F00AEC582 /* AppSelectViewController.swift */; };
 		0B0035402B43D64D00DA140C /* HMHNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B00353F2B43D64D00DA140C /* HMHNavigationBar.swift */; };
+		0B17D3EB2B5104E000CFA3B7 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B17D3EA2B5104E000CFA3B7 /* UserManager.swift */; };
+		0B17D3ED2B5108D200CFA3B7 /* UserDefaultWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B17D3EC2B5108D200CFA3B7 /* UserDefaultWrapper.swift */; };
 		0B2C2D3B2B443BE90023CCFA /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2C2D3A2B443BE90023CCFA /* Image.swift */; };
 		0B2C2D412B4572240023CCFA /* HMHSelectButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2C2D402B4572240023CCFA /* HMHSelectButton.swift */; };
 		0B50F9CB2B369813000C5046 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B50F9CA2B369813000C5046 /* AppDelegate.swift */; };
@@ -174,6 +176,8 @@
 		0B000CEC2B4D9DA800AEC582 /* ApprovePermisionController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApprovePermisionController.swift; sourceTree = "<group>"; };
 		0B000CF02B4DA30F00AEC582 /* AppSelectViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppSelectViewController.swift; sourceTree = "<group>"; };
 		0B00353F2B43D64D00DA140C /* HMHNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMHNavigationBar.swift; sourceTree = "<group>"; };
+		0B17D3EA2B5104E000CFA3B7 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
+		0B17D3EC2B5108D200CFA3B7 /* UserDefaultWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultWrapper.swift; sourceTree = "<group>"; };
 		0B2C2D3A2B443BE90023CCFA /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		0B2C2D402B4572240023CCFA /* HMHSelectButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMHSelectButton.swift; sourceTree = "<group>"; };
 		0B50F9C72B369813000C5046 /* HMH_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HMH_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -333,6 +337,15 @@
 			path = ViewControllers;
 			sourceTree = "<group>";
 		};
+		0B17D3E92B5104B900CFA3B7 /* User */ = {
+			isa = PBXGroup;
+			children = (
+				0B17D3EA2B5104E000CFA3B7 /* UserManager.swift */,
+				0B17D3EC2B5108D200CFA3B7 /* UserDefaultWrapper.swift */,
+			);
+			path = User;
+			sourceTree = "<group>";
+		};
 		0B2C2D3C2B4559AE0023CCFA /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
@@ -484,6 +497,7 @@
 		0B8A89982B369CF800688BA6 /* SupportingFiles */ = {
 			isa = PBXGroup;
 			children = (
+				0B17D3E92B5104B900CFA3B7 /* User */,
 				3666C8782B45F4D900564874 /* AppBlock */,
 				0B8A89992B369D0B00688BA6 /* Base */,
 			);
@@ -1073,6 +1087,7 @@
 				0B8A89AF2B369E4300688BA6 /* HomeModel.swift in Sources */,
 				3666C89F2B485C8F00564874 /* DateCollectionViewCell.swift in Sources */,
 				3666C87A2B45F4F900564874 /* SelectedBlocker.swift in Sources */,
+				0B17D3ED2B5108D200CFA3B7 /* UserDefaultWrapper.swift in Sources */,
 				0BC0EBD42B494459003EF5D4 /* OnboardingSwipeView.swift in Sources */,
 				17314F9B2B4C485B0089A551 /* UserPointHeaderView.swift in Sources */,
 				364923862B4FDCBD00BF7ACA /* NetworkProvider.swift in Sources */,
@@ -1086,6 +1101,7 @@
 				174AF4942B447B5500450D07 /* MyPageViewController.swift in Sources */,
 				0BA193B42B4D089C007E3F9C /* TimeSurveyViewController.swift in Sources */,
 				36A3D9B82B3EBC3B007EA272 /* UILabel+.swift in Sources */,
+				0B17D3EB2B5104E000CFA3B7 /* UserManager.swift in Sources */,
 				0B50F9CB2B369813000C5046 /* AppDelegate.swift in Sources */,
 				0B7817522B4BE0280078E925 /* ProgressBarManager.swift in Sources */,
 				0B8A89C42B369FA000688BA6 /* F.swift in Sources */,

--- a/HMH_iOS/HMH_iOS/Application/SceneDelegate.swift
+++ b/HMH_iOS/HMH_iOS/Application/SceneDelegate.swift
@@ -6,11 +6,27 @@
 //
 
 import UIKit
+import AuthenticationServices
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
-    
+    //
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        appleIDProvider.getCredentialState(forUserID: "000340.8d411a5d11d84e8da0c22ef43dce465a.1657" ?? "") { (credentialState, error) in
+            switch credentialState {
+            case .authorized:
+                print("authorized")
+            case .revoked:
+                print("revoked")
+            case .notFound:
+                print("notFound")
+            default:
+                break
+            }
+        }
+    }
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
@@ -24,7 +40,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             DispatchQueue.main.async{
-                showTabBarViewController()
+                if UserManager.shared.hasAccessToken {
+                    //애플 로그인 토큰 리프레쉬 로직. 성공한다면 엑세스와 리프레시 토큰 업데이트 그러면서 이동
+                    // 토큰 리프레시가 실패 한다. 로그인 컨트롤러로 바로 이동.
+//                    UserManager.shared.updateToken(,)
+                    
+                    showTabBarViewController()
+                } else {
+                    showLoginViewController()
+                }
             }
         }
         

--- a/HMH_iOS/HMH_iOS/Application/SceneDelegate.swift
+++ b/HMH_iOS/HMH_iOS/Application/SceneDelegate.swift
@@ -6,11 +6,27 @@
 //
 
 import UIKit
+import AuthenticationServices
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
     var window: UIWindow?
-    
+    //
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        appleIDProvider.getCredentialState(forUserID: "000340.8d411a5d11d84e8da0c22ef43dce465a.1657" ?? "") { (credentialState, error) in
+            switch credentialState {
+            case .authorized:
+                print("authorized")
+            case .revoked:
+                print("revoked")
+            case .notFound:
+                print("notFound")
+            default:
+                break
+            }
+        }
+    }
     
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
@@ -24,7 +40,15 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             DispatchQueue.main.async{
-                showLoginViewController()
+                if UserManager.shared.hasAccessToken {
+                    //애플 로그인 토큰 리프레쉬 로직. 성공한다면 엑세스와 리프레시 토큰 업데이트 그러면서 이동
+                    // 토큰 리프레시가 실패 한다. 로그인 컨트롤러로 바로 이동.
+//                    UserManager.shared.updateToken(,)
+                    
+                    showTabBarViewController()
+                } else {
+                    showLoginViewController()
+                }
             }
         }
         

--- a/HMH_iOS/HMH_iOS/Global/SupportingFiles/User/UserDefaultWrapper.swift
+++ b/HMH_iOS/HMH_iOS/Global/SupportingFiles/User/UserDefaultWrapper.swift
@@ -1,0 +1,30 @@
+//
+//  UserDefaultWrapper.swift
+//  HMH_iOS
+//
+//  Created by Seonwoo Kim on 1/12/24.
+//
+
+import Foundation
+
+@propertyWrapper
+struct UserDefaultWrapper<T> {
+    
+    var wrappedValue: T? {
+        get {
+            return UserDefaults.standard.object(forKey: self.key) as? T
+        }
+        
+        set {
+            if newValue == nil {
+                UserDefaults.standard.removeObject(forKey: key)
+            } else { UserDefaults.standard.setValue(newValue, forKey: key) }
+        }
+    }
+    
+    private let key: String
+    
+    init(key: String) {
+        self.key = key
+    }
+}

--- a/HMH_iOS/HMH_iOS/Global/SupportingFiles/User/UserManager.swift
+++ b/HMH_iOS/HMH_iOS/Global/SupportingFiles/User/UserManager.swift
@@ -1,0 +1,90 @@
+//
+//  UserManager.swift
+//  HMH_iOS
+//
+//  Created by Seonwoo Kim on 1/12/24.
+//
+
+import Foundation
+
+final class UserManager {
+    static let shared = UserManager()
+    
+    @UserDefaultWrapper<String>(key: "accessToken") private(set) var accessToken
+    @UserDefaultWrapper<String>(key: "refreshToken") private(set) var refreshToken
+    @UserDefaultWrapper<String>(key: "AppleToken") private(set) var appleToken
+    @UserDefaultWrapper<String>(key: "userIdentifier") private(set) var appleUserIdentifier
+    @UserDefaultWrapper<String>(key: "familyName") private(set) var familyName
+    @UserDefaultWrapper<String>(key: "givenName") private(set) var givenName
+    @UserDefaultWrapper<String>(key: "fullName") private(set) var fullName
+    @UserDefaultWrapper<Int>(key: "userId") private(set) var userId
+    
+    var hasAccessToken: Bool { return self.accessToken != nil }
+    var getAccessToken: String { return self.accessToken ?? "" }
+    var getRefreshToken: String { return self.refreshToken ?? "" }
+    var getAppleToken: String { return self.appleToken ?? "" }
+    var getUserIdentifier: String { return self.appleUserIdentifier ?? "" }
+    var getUserName: String { return self.familyName ?? "" }
+    var getGivenName: String { return self.givenName ?? "" }
+    var getFullName: String { return self.fullName ?? "" }
+    var getUserId: Int { return self.userId ?? 0}
+    
+    var haveFullName: Bool {
+        if fullName == "" {
+            return false
+        } else if fullName == nil {
+            return false
+        } else {
+            return true
+        }
+    }
+    
+    private init() {}
+}
+
+extension UserManager {
+    func updateToken(_ accessToken: String, _ refreshToken: String) {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+    }
+
+    func updateAppleToken(_ appleToken: String) {
+        self.appleToken = appleToken
+    }
+    
+    func updateUserIdentifier(_ appleUserIdentifier: String) {
+        self.appleUserIdentifier = appleUserIdentifier
+    }
+
+    func updateUserName(_ givenName: String, _ familyName: String) {
+        self.givenName = givenName
+        self.familyName = familyName
+        self.fullName = familyName + givenName
+    }
+    
+    func updateUserId(_ userId: Int) {
+        self.userId = userId
+    }
+
+    func setUserIdForApple(userId: String) {
+        self.appleUserIdentifier = appleUserIdentifier
+    }
+        
+    func clearAll() {
+        self.accessToken = nil
+        self.refreshToken = nil
+        self.appleToken = nil
+        self.appleUserIdentifier = nil
+        self.familyName = nil
+        self.givenName = nil
+        self.fullName = nil
+        self.userId = nil
+    }
+    
+    func clearData() {
+        self.accessToken = nil
+        self.refreshToken = nil
+        self.appleToken = nil
+        self.appleUserIdentifier = nil
+    }
+}

--- a/HMH_iOS/HMH_iOS/Global/SupportingFiles/User/UserManager.swift
+++ b/HMH_iOS/HMH_iOS/Global/SupportingFiles/User/UserManager.swift
@@ -47,7 +47,7 @@ extension UserManager {
         self.accessToken = accessToken
         self.refreshToken = refreshToken
     }
-
+    
     func updateAppleToken(_ appleToken: String) {
         self.appleToken = appleToken
     }
@@ -55,7 +55,7 @@ extension UserManager {
     func updateUserIdentifier(_ appleUserIdentifier: String) {
         self.appleUserIdentifier = appleUserIdentifier
     }
-
+    
     func updateUserName(_ givenName: String, _ familyName: String) {
         self.givenName = givenName
         self.familyName = familyName
@@ -65,11 +65,11 @@ extension UserManager {
     func updateUserId(_ userId: Int) {
         self.userId = userId
     }
-
+    
     func setUserIdForApple(userId: String) {
         self.appleUserIdentifier = appleUserIdentifier
     }
-        
+    
     func clearAll() {
         self.accessToken = nil
         self.refreshToken = nil

--- a/HMH_iOS/HMH_iOS/HMH_iOS.entitlements
+++ b/HMH_iOS/HMH_iOS/HMH_iOS.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 	<key>com.apple.developer.family-controls</key>
 	<true/>
 </dict>

--- a/HMH_iOS/HMH_iOS/Presentation/Login/ViewControllers/LoginViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Login/ViewControllers/LoginViewController.swift
@@ -12,30 +12,9 @@ import Then
 import AuthenticationServices
 
 final class LoginViewController: UIViewController {
+    
+    private let swipeView = OnboardingSwipeView()
     let authorizationButton = ASAuthorizationAppleIDButton(authorizationButtonType: .signIn, authorizationButtonStyle: .white)
-    func setAppleLoginButton() {
-        authorizationButton.addTarget(self, action: #selector(handleAuthorizationAppleIDButtonPress), for: .touchUpInside)
-        self.view.addSubview(authorizationButton)
-        authorizationButton.translatesAutoresizingMaskIntoConstraints = false
-    }
-    
-    @objc
-    func handleAuthorizationAppleIDButtonPress() {
-        let appleIDProvider = ASAuthorizationAppleIDProvider()
-        let request = appleIDProvider.createRequest()
-        request.requestedScopes = [.fullName, .email]
-        print(request, "👍")
-        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
-        authorizationController.delegate = self
-        authorizationController.presentationContextProvider = self
-        authorizationController.performRequests()
-    }
-    
-    @objc func appleButtonTaped() {
-        print("tap")
-    }
-    
-    let swipeView = OnboardingSwipeView()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -66,6 +45,32 @@ final class LoginViewController: UIViewController {
             $0.height.equalTo(480)
         }
     }
+}
+
+extension LoginViewController {
+    
+    func setAppleLoginButton() {
+        authorizationButton.addTarget(self, action: #selector(handleAuthorizationAppleIDButtonPress), for: .touchUpInside)
+        self.view.addSubview(authorizationButton)
+        authorizationButton.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    @objc
+    func handleAuthorizationAppleIDButtonPress() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.email]
+        print(request, "👍")
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
+    }
+    
+    @objc func appleButtonTaped() {
+        print("tap")
+    }
+    
 }
 
 

--- a/HMH_iOS/HMH_iOS/Presentation/Login/ViewControllers/LoginViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Login/ViewControllers/LoginViewController.swift
@@ -13,10 +13,33 @@ import AuthenticationServices
 
 final class LoginViewController: UIViewController {
     let authorizationButton = ASAuthorizationAppleIDButton(authorizationButtonType: .signIn, authorizationButtonStyle: .white)
+    func setAppleLoginButton() {
+        authorizationButton.addTarget(self, action: #selector(handleAuthorizationAppleIDButtonPress), for: .touchUpInside)
+        self.view.addSubview(authorizationButton)
+        authorizationButton.translatesAutoresizingMaskIntoConstraints = false
+    }
+    
+    @objc
+    func handleAuthorizationAppleIDButtonPress() {
+        let appleIDProvider = ASAuthorizationAppleIDProvider()
+        let request = appleIDProvider.createRequest()
+        request.requestedScopes = [.fullName, .email]
+        print(request, "👍")
+        let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+        authorizationController.delegate = self
+        authorizationController.presentationContextProvider = self
+        authorizationController.performRequests()
+    }
+    
+    @objc func appleButtonTaped() {
+        print("tap")
+    }
+    
     let swipeView = OnboardingSwipeView()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setAppleLoginButton()
         setUI()
     }
     
@@ -43,11 +66,74 @@ final class LoginViewController: UIViewController {
             $0.height.equalTo(480)
         }
     }
-    
-    private func setAppleLoginButton() {
-        self.view.addSubview(authorizationButton)
-        authorizationButton.translatesAutoresizingMaskIntoConstraints = false
-    }
 }
 
 
+extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding{
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        //로그인 성공
+        switch authorization.credential {
+        case let appleIDCredential as ASAuthorizationAppleIDCredential:
+            // You can create an account in your system.
+            let userIdentifier = appleIDCredential.user
+            let fullName = appleIDCredential.fullName
+            let email = appleIDCredential.email
+            
+            UserDefaults.standard.set(userIdentifier, forKey: "userIdentifier")
+            if  let authorizationCode = appleIDCredential.authorizationCode,
+                let identityToken = appleIDCredential.identityToken,
+                let authCodeString = String(data: authorizationCode, encoding: .utf8),
+                let identifyTokenString = String(data: identityToken, encoding: .utf8) {
+                print("authorizationCode: \(authorizationCode)")
+                print("identityToken: \(identityToken)")
+                print("authCodeString: \(authCodeString)")
+                print("identifyTokenString: \(identifyTokenString)")
+                print("🚨", appleIDCredential)
+                if let bundleID = Bundle.main.bundleIdentifier {
+                    UserDefaults.standard.removePersistentDomain(forName: bundleID)
+                }
+                //                saveToUserDefaults("authorizationCode",keyValue: authorizationCode)
+                //                saveToUserDefaults("identityToken",keyValue: identityToken)
+                //                saveToUserDefaults(authCodeString,keyValue:"authCodeString")
+                //                saveToUserDefaults(identifyTokenString,keyValue:"identifyTokenString")
+                //                saveToUserDefaults("cool",keyValue:"userIdentifier")
+                
+            }
+            
+            print("useridentifier: \(userIdentifier)")
+            
+            
+            
+            //Move to MainPage
+            //let validVC = SignValidViewController()
+            //validVC.modalPresentationStyle = .fullScreen
+            //present(validVC, animated: true, completion: nil)
+            
+        case let passwordCredential as ASPasswordCredential:
+            // Sign in using an existing iCloud Keychain credential.
+            let username = passwordCredential.user
+            let password = passwordCredential.password
+            
+            print("username: \(username)")
+            print("password: \(password)")
+            
+        default:
+            break
+        }
+    }
+    
+    func saveToUserDefaults(_ content: String, keyValue: String) {
+        // Save the userId to UserDefaults
+        UserDefaults.standard.set(content, forKey: keyValue)
+    }
+    
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        // 로그인 실패(유저의 취소도 포함)
+        print("login failed - \(error.localizedDescription)")
+    }
+}

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/Models/SignInModel.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/Models/SignInModel.swift
@@ -5,26 +5,26 @@
 //  Created by Seonwoo Kim on 1/9/24.
 //
 
-import Foundation
-
-struct SignInModel {
-    let socialPlatform: String
-    let onboarding: Onboarding
-    let challenge: Challenge
-}
-
-struct Onboarding {
-    let averageUseTime: String
-    let problem: [String]
-}
-
-struct Challenge {
-    let period: Int
-    let goalTime: Int
-    let apps: [Apps]
-}
-
-struct Apps {
-    let appCode: String
-    let goalTime: Int
-}
+//import Foundation
+//
+//struct SignInModel {
+//    let socialPlatform: String
+//    let onboarding: Onboarding
+//    let challenge: Challenge
+//}
+//
+//struct Onboarding {
+//    let averageUseTime: String
+//    let problem: [String]
+//}
+//
+//struct Challenge {
+//    let period: Int
+//    let goalTime: Int
+//    let apps: [Apps]
+//}
+//
+//struct Apps {
+//    let appCode: String
+//    let goalTime: Int
+//}


### PR DESCRIPTION
## 👾 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 애플 로그인 권한 설정 부분에서 sign in with apple을 추가하였습니다.
### UserWrapper 생성
- UserWrapper는 UserDefault의 처리를 용이하게 해줍니다. 
- 설정과 업데이트와 리무브를 이쪽에서 판단하여 처리해주어 코드가 간결해집니다.
- UserDefault와 UserManager를 쉽게 동기화 시켜 줍니다.
- 애플 로그인 버튼을 눌렀을 때 이벤트를 구현하였습니다. 
- 애플 로그인이 성공했을 때의 로직을 간단하게 구현하였습니다. 

### User관련 정보 접근을 용이하게 하는 UserManager 파일을 생성하였습니다.
- 값을 설정하거나 수정할때 update~ 에 해당되는 메소드를 사용하여 설정해줍니다.
- UserManager 파일의 요소에 접근하고 싶으면, get~ 에 해당되는 메소드를 골라 불러와 줍니다.
- 임의로 다음과 같은 로직을 추가하여 구현하였습니다.
```swift
            if (UserManager.shared.appleUserIdentifier != nil) {
                let nextViewController = TabBarController()
                self.navigationController?.pushViewController(nextViewController, animated: true)
            } else {
                let nextViewController = TimeSurveyViewController()
                self.navigationController?.pushViewController(nextViewController, animated: true)
            }
```

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- SignInModel의 네이밍이 구체화가 안된 이슈로 에러가 발생할 수 있을 것 같아, 일단 에러처리 하였습니다. 
- SceneDelegate에 애플로그인에 따른 상태처리관련 코드는 일단 남겨두었습니다.
- API는 아직 추가하지 않았습니다. 일단 주석으로 코멘트를 달아 놨습니다. 추후에 적용할 생각입니다.
- UI구현은 따로 없으므로 기기대응 화면 추가 하지 않겠습니다.

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 로그인 화면 | ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/fd0d8722-d4af-4933-b0c9-37d189a3e817) |

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #46 
