### PR TITLE
Fix [#62] 루트 뷰 컨트롤러 이동 수정

### DIFF
--- a/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
+++ b/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		0B0035402B43D64D00DA140C /* HMHNavigationBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B00353F2B43D64D00DA140C /* HMHNavigationBar.swift */; };
 		0B17D3EB2B5104E000CFA3B7 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B17D3EA2B5104E000CFA3B7 /* UserManager.swift */; };
 		0B17D3ED2B5108D200CFA3B7 /* UserDefaultWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B17D3EC2B5108D200CFA3B7 /* UserDefaultWrapper.swift */; };
+		0B17D3F12B51AD4B00CFA3B7 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B17D3F02B51AD4B00CFA3B7 /* UIViewController+.swift */; };
 		0B2C2D3B2B443BE90023CCFA /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2C2D3A2B443BE90023CCFA /* Image.swift */; };
 		0B2C2D412B4572240023CCFA /* HMHSelectButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B2C2D402B4572240023CCFA /* HMHSelectButton.swift */; };
 		0B50F9CB2B369813000C5046 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B50F9CA2B369813000C5046 /* AppDelegate.swift */; };
@@ -184,6 +185,7 @@
 		0B00353F2B43D64D00DA140C /* HMHNavigationBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMHNavigationBar.swift; sourceTree = "<group>"; };
 		0B17D3EA2B5104E000CFA3B7 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
 		0B17D3EC2B5108D200CFA3B7 /* UserDefaultWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultWrapper.swift; sourceTree = "<group>"; };
+		0B17D3F02B51AD4B00CFA3B7 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		0B2C2D3A2B443BE90023CCFA /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		0B2C2D402B4572240023CCFA /* HMHSelectButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMHSelectButton.swift; sourceTree = "<group>"; };
 		0B50F9C72B369813000C5046 /* HMH_iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HMH_iOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -485,6 +487,7 @@
 				36A3D9B72B3EBC3B007EA272 /* UILabel+.swift */,
 				36A3D9BB2B3EBD2D007EA272 /* UIScreen+.swift */,
 				3666C88C2B471B1D00564874 /* UIImage+.swift */,
+				0B17D3F02B51AD4B00CFA3B7 /* UIViewController+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1111,6 +1114,7 @@
 				364923862B4FDCBD00BF7ACA /* NetworkProvider.swift in Sources */,
 				364923702B4F524D00BF7ACA /* MoyaLoggerPlugin.swift in Sources */,
 				36A3D9C02B409CBD007EA272 /* Font.swift in Sources */,
+				0B17D3F12B51AD4B00CFA3B7 /* UIViewController+.swift in Sources */,
 				174AF4902B447B3C00450D07 /* MyPageModels.swift in Sources */,
 				174AF4982B447CF100450D07 /* ChanllengeModels.swift in Sources */,
 				17CF9FBD2B4DC757000DD09C /* HMHHomeView.swift in Sources */,

--- a/HMH_iOS/HMH_iOS/Application/SceneDelegate.swift
+++ b/HMH_iOS/HMH_iOS/Application/SceneDelegate.swift
@@ -33,9 +33,11 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         
         let window = UIWindow(windowScene: windowScene)
         self.window = window
-        
         let splashViewController = SplashViewController()
         window.rootViewController = splashViewController
+        if let navigationController = window.rootViewController as? UINavigationController {
+            navigationController.isNavigationBarHidden = true
+        }
         window.makeKeyAndVisible()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {

--- a/HMH_iOS/HMH_iOS/Global/Extension/UIViewController+.swift
+++ b/HMH_iOS/HMH_iOS/Global/Extension/UIViewController+.swift
@@ -1,0 +1,20 @@
+//
+//  UIViewController+.swift
+//  HMH_iOS
+//
+//  Created by Seonwoo Kim on 1/13/24.
+//
+
+import UIKit
+
+extension UIViewController {
+    func setRootViewController(_ viewController: UIViewController) {
+        let navigationController = UINavigationController(rootViewController: viewController)
+        let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
+        guard let delegate = sceneDelegate else {
+            return
+        }
+        delegate.window?.rootViewController = navigationController
+    }
+}
+

--- a/HMH_iOS/HMH_iOS/Presentation/Common/CustomTabbar/TabBarController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Common/CustomTabbar/TabBarController.swift
@@ -68,7 +68,6 @@ final class TabBarController: UITabBarController {
         let tabBarHeight: CGFloat = UIScreen.main.isLongerThan812pt ? 52.0.adjusted : 58.0.adjusted
         tabBar.frame.size.height = tabBarHeight + safeAreaHeight
         tabBar.frame.origin.y = view.frame.height - tabBarHeight - safeAreaHeight
-
     }
     
     private func setTabBar() {
@@ -117,5 +116,6 @@ final class TabBarController: UITabBarController {
                 tabBarItem.tabBarItem.titlePositionAdjustment = UIOffset(horizontal: 0, vertical: -1.adjusted)
             }
         }
+        selectedIndex = 1 
     }
 }

--- a/HMH_iOS/HMH_iOS/Presentation/Common/UIComponets/HMHNavigationBar.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Common/UIComponets/HMHNavigationBar.swift
@@ -34,10 +34,6 @@ final class HMHNavigationBar: UIView {
         $0.tintColor = .gray3
     }
     
-    private let logoImageView = UIImageView().then {
-        $0.backgroundColor = .blue
-    }
-    
     private let titleLabel = UILabel().then {
         $0.textColor = .white
         $0.font = UIFont.iosText3Semibold18
@@ -79,7 +75,7 @@ final class HMHNavigationBar: UIView {
             self.addSubviews(backArrowButton, titleLabel, pointButton)
             pointButton.addSubview(pointImageView)
         case .logo:
-            self.addSubviews(logoImageView)
+            return
         }
     }
     
@@ -113,11 +109,7 @@ final class HMHNavigationBar: UIView {
                 }
                 
             case .logo:
-                logoImageView.snp.makeConstraints {
-                    $0.centerY.equalToSuperview().offset(50.adjusted)
-                    $0.leading.equalToSuperview().inset(20.adjusted)
-                    $0.size.equalTo(24.adjusted)
-                }
+                return
             }
         } else {
             self.snp.makeConstraints {
@@ -146,11 +138,7 @@ final class HMHNavigationBar: UIView {
                     $0.edges.equalToSuperview()
                 }
             case .logo:
-                logoImageView.snp.makeConstraints {
-                    $0.centerY.equalToSuperview().offset(50.adjusted)
-                    $0.leading.equalToSuperview().inset(20.adjusted)
-                    $0.size.equalTo(24.adjusted)
-                }
+                return
             }
         }
     }

--- a/HMH_iOS/HMH_iOS/Presentation/Login/ViewControllers/LoginViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Login/ViewControllers/LoginViewController.swift
@@ -103,7 +103,6 @@ extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
             } else {
                 setRootViewController(TimeSurveyViewController())
             }
-    
         default:
             break
         }

--- a/HMH_iOS/HMH_iOS/Presentation/Login/ViewControllers/LoginViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Login/ViewControllers/LoginViewController.swift
@@ -99,11 +99,9 @@ extension LoginViewController: ASAuthorizationControllerDelegate, ASAuthorizatio
             print(UserManager.shared.getUserIdentifier)
             print(UserManager.shared.getUserName)
             if (UserManager.shared.appleUserIdentifier != nil) {
-                let nextViewController = TabBarController()
-                self.navigationController?.pushViewController(nextViewController, animated: true)
+                setRootViewController(TabBarController())
             } else {
-                let nextViewController = TimeSurveyViewController()
-                self.navigationController?.pushViewController(nextViewController, animated: true)
+                setRootViewController(TimeSurveyViewController())
             }
     
         default:

--- a/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/SignInCompleteViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Onboarding/ViewControllers/SignInCompleteViewController.swift
@@ -77,13 +77,7 @@ final class SignInCompleteViewController: OnboardingBaseViewController {
 
 extension SignInCompleteViewController: NextViewPushDelegate {
     func didTapButton() {
-        let nextViewController = TabBarController()
-        let navigationController = UINavigationController(rootViewController: nextViewController)
-        let sceneDelegate = UIApplication.shared.connectedScenes.first?.delegate as? SceneDelegate
-        guard let delegate = sceneDelegate else {
-            return
-        }
-        delegate.window?.rootViewController = navigationController
+        setRootViewController(TabBarController())
     }
 }
 


### PR DESCRIPTION
## 👾 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 기존에 로그안 뷰 컨트롤러에서 push로 다음 뷰로 이동하여 스택이 형성되는 문제를 수정하였습니다.
- rootViewController로 이동하는 로직을 UIViewController+로 형성하여 extenstion으로 사용할 수 있게 하였습니다.
- setRootViewController 함수로 설정하여 구현할 수 있습니다.
```swift
setRootViewController(TabBarController())

```
- TabBar의 진입 화면을 홈 화면으로 설정했습니다.

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 스택이 안쌓여야할 부분에는 앞으로 위의 코드를 사용해 주세요!

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
|뷰 | ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/8f9fc5e2-fdca-48c8-8a81-a503c957b7a3) |

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #62 
