### PR TITLE
Fix [#36] 목표 시간 설정뷰

### DIFF
--- a/HMH_iOS/HMH_iOS/Global/Literals/String/String.swift
+++ b/HMH_iOS/HMH_iOS/Global/Literals/String/String.swift
@@ -49,6 +49,11 @@ enum StringLiteral {
             static var backgroundViewId = "GrayBackground"
             static var appAddFooterViewID = "appAddFooter"
         }
+        
+        enum Time {
+            static var timeLabel = "시간"
+            static var minLabel = "분"
+        }
     }
     
     enum myPage {

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/GoalTimeSelectView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/GoalTimeSelectView.swift
@@ -14,8 +14,8 @@ import FamilyControls
 class GoalTimeSelectView: UIView {
     
     var screenTime = ScreenTime.shared
-    private let timePicker = HMHTimePickerView(type: .specificTime)
-    private let timeLable = UILabel().then {
+    private let hourPicker = HMHTimePickerView(type: .specificTime)
+    private let hourLabel = UILabel().then {
         $0.text = StringLiteral.Challenge.Time.timeLabel
         $0.font = .iosText2Medium20
         $0.textColor = .gray2
@@ -44,24 +44,24 @@ class GoalTimeSelectView: UIView {
     }
     
     private func setHierarchy() {
-        self.addSubviews(timePicker,timeLable,minPicker,minLable)
+        self.addSubviews(hourPicker,hourLabel,minPicker,minLable)
     }
     
     private func setConstraints() {
-        timePicker.snp.makeConstraints {
+        hourPicker.snp.makeConstraints {
             $0.centerY.equalToSuperview()
             $0.leading.equalToSuperview().offset(72.adjusted)
             $0.width.equalTo(67.adjusted)
         }
         
-        timeLable.snp.makeConstraints {
+        hourLabel.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalTo(timePicker.snp.trailing).offset(-7.adjusted)
+            $0.leading.equalTo(hourPicker.snp.trailing).offset(-7.adjusted)
         }
         
         minPicker.snp.makeConstraints {
             $0.centerY.equalToSuperview()
-            $0.leading.equalTo(timeLable.snp.trailing).offset(23.adjusted)
+            $0.leading.equalTo(hourLabel.snp.trailing).offset(23.adjusted)
             $0.width.equalTo(67.adjusted)
         }
         

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/GoalTimeSelectView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/GoalTimeSelectView.swift
@@ -14,7 +14,18 @@ import FamilyControls
 class GoalTimeSelectView: UIView {
     
     var screenTime = ScreenTime.shared
-    private let picker = SpecificTimePickerView()
+    private let timePicker = HMHTimePickerView(type: .specificTime)
+    private let timeLable = UILabel().then {
+        $0.text = StringLiteral.Challenge.Time.timeLabel
+        $0.font = .iosText2Medium20
+        $0.textColor = .gray2
+    }
+    private let minPicker = HMHTimePickerView(type: .specificMinute)
+    private let minLable = UILabel().then {
+        $0.text = StringLiteral.Challenge.Time.minLabel
+        $0.font = .iosText2Medium20
+        $0.textColor = .gray2
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -33,13 +44,30 @@ class GoalTimeSelectView: UIView {
     }
     
     private func setHierarchy() {
-        self.addSubviews(picker)
+        self.addSubviews(timePicker,timeLable,minPicker,minLable)
     }
     
     private func setConstraints() {
-        picker.snp.makeConstraints {
-            $0.center.equalToSuperview()
-            $0.width.equalTo(335.adjusted)
+        timePicker.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalToSuperview().offset(72.adjusted)
+            $0.width.equalTo(67.adjusted)
+        }
+        
+        timeLable.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(timePicker.snp.trailing).offset(-7.adjusted)
+        }
+        
+        minPicker.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(timeLable.snp.trailing).offset(23.adjusted)
+            $0.width.equalTo(67.adjusted)
+        }
+        
+        minLable.snp.makeConstraints {
+            $0.centerY.equalToSuperview()
+            $0.leading.equalTo(minPicker.snp.trailing).offset(2.adjusted)
         }
     }
     


### PR DESCRIPTION
## 👾 작업 내용
변경된 `pickerView`를 적용한 목표 시간 뷰입니다. 


## 🚀 PR Point
- `SpecificTimePicker`가 사라졌습니다. 

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 목표 시간 설정뷰 | ![Simulator Screenshot - iPhone 13 mini - 2024-01-14 at 00 43 01](https://github.com/Team-HMH/HMH-iOS/assets/68178395/3cf41382-b6ca-4c2a-8ed9-77c5d43da179) |

## 🚀 기기 대응
|    기기명    |   Iphone 13 mini  | Iphone 14 | Iphone 15 pro | Iphone SE(3rd) |
| :-------------: | :----------: | :----------: | :----------: |:----------: |
| 스크린샷 | ![Simulator Screenshot - iPhone 13 mini - 2024-01-14 at 00 43 01](https://github.com/Team-HMH/HMH-iOS/assets/68178395/3918efe2-b6b6-4b16-b3b0-42558552fe97) | ![image](https://github.com/Team-HMH/HMH-iOS/assets/68178395/088a9560-0362-4f29-8930-2cc1ca2114aa) | ![Simulator Screenshot - iPhone 15 Pro - 2024-01-14 at 00 47 57](https://github.com/Team-HMH/HMH-iOS/assets/68178395/37210a58-1308-43c6-89cd-80c0df0cc36f) | ![Simulator Screenshot - iPhone SE (3rd generation) - 2024-01-14 at 00 38 58](https://github.com/Team-HMH/HMH-iOS/assets/68178395/a270feff-fbb3-4f62-b049-262ed8dead35) |

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #36 
