### PR TITLE
Fix [#108] Challenge 특정 앱 삭제 Alert 구현

### DIFF
--- a/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
+++ b/HMH_iOS/HMH_iOS.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		0BC0EBD42B494459003EF5D4 /* OnboardingSwipeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BC0EBD32B494459003EF5D4 /* OnboardingSwipeView.swift */; };
 		0BD98DB92B4D671600E35188 /* SplashViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD98DB82B4D671600E35188 /* SplashViewController.swift */; };
 		0BD98DBE2B4D6AB700E35188 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BD98DBD2B4D6AB700E35188 /* LoginViewController.swift */; };
+		0BEE2A682B58EF430020B502 /* HMHDeleteAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BEE2A672B58EF430020B502 /* HMHDeleteAlert.swift */; };
 		0BFD2FB42B4EE71900C6327F /* SignInCompleteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BFD2FB32B4EE71900C6327F /* SignInCompleteViewController.swift */; };
 		17314F7F2B485E150089A551 /* CustomAlertButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17314F7E2B485E150089A551 /* CustomAlertButton.swift */; };
 		17314F832B486BEC0089A551 /* AlertViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17314F822B486BEC0089A551 /* AlertViewController.swift */; };
@@ -289,6 +290,7 @@
 		0BC0EBD32B494459003EF5D4 /* OnboardingSwipeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingSwipeView.swift; sourceTree = "<group>"; };
 		0BD98DB82B4D671600E35188 /* SplashViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		0BD98DBD2B4D6AB700E35188 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		0BEE2A672B58EF430020B502 /* HMHDeleteAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMHDeleteAlert.swift; sourceTree = "<group>"; };
 		0BFD2FB32B4EE71900C6327F /* SignInCompleteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInCompleteViewController.swift; sourceTree = "<group>"; };
 		17314F7E2B485E150089A551 /* CustomAlertButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAlertButton.swift; sourceTree = "<group>"; };
 		17314F822B486BEC0089A551 /* AlertViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlertViewController.swift; sourceTree = "<group>"; };
@@ -883,6 +885,7 @@
 				17314F842B497FDE0089A551 /* HMHLogoutAlert.swift */,
 				17314F862B49853C0089A551 /* HMHQuitAlert.swift */,
 				36610E3B2B5463280044F1CA /* HMHPushAlert.swift */,
+				0BEE2A672B58EF430020B502 /* HMHDeleteAlert.swift */,
 			);
 			path = CustomAlert;
 			sourceTree = "<group>";
@@ -1456,6 +1459,7 @@
 				17CF9FC92B4EE964000DD09C /* AppUsingProgressViewCell.swift in Sources */,
 				0B000CEB2B4D9D9100AEC582 /* SelectTotalTimeController.swift in Sources */,
 				360D110E2B541DB4008BE85A /* UserDefault+.swift in Sources */,
+				0BEE2A682B58EF430020B502 /* HMHDeleteAlert.swift in Sources */,
 				0B1AE8212B53ABC400CF5154 /* SignUpResponseDTO.swift in Sources */,
 				17314F872B49853C0089A551 /* HMHQuitAlert.swift in Sources */,
 				364923A02B505F2000BF7ACA /* CreateChallengeRequestDTO.swift in Sources */,

--- a/HMH_iOS/HMH_iOS/Global/Literals/String/String.swift
+++ b/HMH_iOS/HMH_iOS/Global/Literals/String/String.swift
@@ -87,14 +87,16 @@ enum StringLiteral {
     enum AlertTitle {
         static let logout = "하면함을 로그아웃 하시겠어요?"
         static let quit = "정말 하면함을 탈퇴 하시겠어요?"
-        static let push = "을(를)\n삭제하시겠어요?"
+        static let push = "을(를)\n계속 사용하시겠어요?"
         static let challenge = "새로운 챌린지 생성 완료"
+        static let delete = "을(를)\n삭제하시겠어요?"
     }
     
     enum AlertDescription {
         static let quit = "회원탈퇴 후 유저 정보는 30일 동안\n임시보관되며, 이후 영구 삭제됩니다"
-        static let push = "집계되고 있던 앱의 사용 시간은\n총 사용 시간에서도 차감돼요"
+        static let push = "사용 시간을 연장하면\n챌린지를 실패해요"
         static let challenge = "블랙홀 탈출을 위한\n새로운 여정을 시작해 보아요"
+        static let delete = "집계되고 있던 앱의 사용 시간은\n총 사용 시간에서도 차감돼요"
     }
     
     enum OnboardingButton {

--- a/HMH_iOS/HMH_iOS/Global/Protocols/AlertDelegate.swift
+++ b/HMH_iOS/HMH_iOS/Global/Protocols/AlertDelegate.swift
@@ -11,4 +11,5 @@ protocol AlertDelegate: AnyObject {
     func enabledButtonTapped()
     func alertDismissTapped()
     func confirmButtonTapped()
+    func deleteButtonTapped()
 }

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Cells/HeaderFooterView/TitleCollectionReusableView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Cells/HeaderFooterView/TitleCollectionReusableView.swift
@@ -85,13 +85,4 @@ final class TitleCollectionReusableView: UICollectionReusableView {
             button.setButtonText(buttonTitle: StringLiteral.Challenge.Date.challengeButton)
         }
     }
-    
-    @objc func deleteButtonDidTapped() {
-        if isButtonTapped {
-            
-        } else {
-            
-        }
-        isButtonTapped.toggle()
-    }
 }

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/ViewControllers/ChallengeViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/ViewControllers/ChallengeViewController.swift
@@ -117,8 +117,4 @@ extension ChallengeViewController: UICollectionViewDelegate {
             }
         }
     }
-
 }
-
-
-

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/ViewControllers/ChallengeViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/ViewControllers/ChallengeViewController.swift
@@ -11,8 +11,8 @@ import SnapKit
 import Then
 
 final class ChallengeViewController: UIViewController {
-    
     var isCreatedChallenge = false
+    var decodedIndex: Int = 0
     func updateChallengeStatus(isCreatedChallenge: Bool) {
         self.isCreatedChallenge = isCreatedChallenge
         configureTabBar(isCreatedChallenge: isCreatedChallenge)
@@ -27,7 +27,7 @@ final class ChallengeViewController: UIViewController {
     
     let challengeView = ChallengeView(frame: .zero, appAddButtonViewModel: BlockingApplicationModel.shared)
     
-    private var selectedIndex = IndexPath()
+    var selectedIndex = IndexPath()
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
@@ -79,6 +79,10 @@ final class ChallengeViewController: UIViewController {
         let nextViewController = CreatePeriodController()
         self.navigationController?.pushViewController(nextViewController, animated: false)
     }
+    
+    func deleteTap() {
+        challengeView.deleteCell()
+    }
 }
 
 
@@ -93,6 +97,8 @@ extension ChallengeViewController: UICollectionViewDelegate {
     }
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        self.decodedIndex = indexPath.item
+        print(decodedIndex)
         if selectedIndex == [] {
             selectedIndex = [1,0]
         }
@@ -102,14 +108,17 @@ extension ChallengeViewController: UICollectionViewDelegate {
             }
             if let currentSelectedCell = collectionView.cellForItem(at: indexPath) as? AppListCollectionViewCell {
                 currentSelectedCell.isSelectedCell = true
+
                 self.selectedIndex = indexPath
                 let alertController = AlertViewController()
                 alertController.setAlertType(.delete)
                 alertController.modalPresentationStyle = .overFullScreen
                 self.present(alertController, animated: false, completion: nil)
             }
-            
         }
     }
+
 }
+
+
 

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/ViewControllers/ChallengeViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/ViewControllers/ChallengeViewController.swift
@@ -25,7 +25,7 @@ final class ChallengeViewController: UIViewController {
                                                  isBackGroundGray: true,
                                                  titleText: StringLiteral.Challenge.NavigationBarTitle)
     
-    private let challengeView = ChallengeView(frame: .zero, appAddButtonViewModel: BlockingApplicationModel.shared)
+    let challengeView = ChallengeView(frame: .zero, appAddButtonViewModel: BlockingApplicationModel.shared)
     
     private var selectedIndex = IndexPath()
     
@@ -68,7 +68,7 @@ final class ChallengeViewController: UIViewController {
             alertController.setAlertType(.Challenge)
             alertController.modalPresentationStyle = .overFullScreen
             self.present(alertController, animated: false, completion: nil)
-        }
+        } 
     }
     
     private func setDelegate() {
@@ -103,8 +103,13 @@ extension ChallengeViewController: UICollectionViewDelegate {
             if let currentSelectedCell = collectionView.cellForItem(at: indexPath) as? AppListCollectionViewCell {
                 currentSelectedCell.isSelectedCell = true
                 self.selectedIndex = indexPath
+                let alertController = AlertViewController()
+                alertController.setAlertType(.delete)
+                alertController.modalPresentationStyle = .overFullScreen
+                self.present(alertController, animated: false, completion: nil)
             }
             
         }
     }
 }
+

--- a/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Challenge/Views/ChallengeView.swift
@@ -14,14 +14,13 @@ import Then
 import FamilyControls
 
 final class ChallengeView: UIView {
-    
     private var appAddButtonViewModel: BlockingApplicationModel = BlockingApplicationModel.shared
     private var cancellables: Set<AnyCancellable> = []
     var isChallengeComplete: Bool = true
     
     private let goalTime: Int = 3
     private var days: Int = 7
-    private var appList: [AppModel] = [AppModel(appIcon: "", appName: "Instagram", appUseTime: "1시간 20분"),
+    var appList: [AppModel] = [AppModel(appIcon: "", appName: "Instagram", appUseTime: "1시간 20분"),
                                        AppModel(appIcon: "", appName: "Youtube", appUseTime: "1시간")]
     var isDeleteMode: Bool = false {
         didSet {
@@ -95,6 +94,11 @@ final class ChallengeView: UIView {
     @objc private func deleteButtonTapped() {
         isDeleteMode.toggle()
     }
+    
+    func deleteCell() {
+        print("tap")
+    }
+
 }
 
 extension ChallengeView: UICollectionViewDataSource {
@@ -273,3 +277,4 @@ extension ChallengeView {
         return nil
     }
 }
+	

--- a/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/AlertViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/AlertViewController.swift
@@ -120,6 +120,13 @@ final class AlertViewController: UIViewController {
 }
 
 extension AlertViewController: AlertDelegate {
+    func deleteButtonTapped() {
+        let challengeController = ChallengeViewController()
+        challengeController.deleteTap()
+        dismiss(animated: false) {
+            (self.okAction ?? self.emptyActions)()
+        }
+    }
     func confirmButtonTapped() {
         setRootViewController(TabBarController())
     }
@@ -139,7 +146,7 @@ extension AlertViewController: AlertDelegate {
                 UserManager.shared.clearAll()
             }
         }
-
+        
         dismiss(animated: false) {
             let loginViewController = LoginViewController()
             if let window = UIApplication.shared.windows.first {
@@ -157,3 +164,4 @@ extension AlertViewController: AlertDelegate {
         }
     }
 }
+

--- a/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/AlertViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/AlertViewController.swift
@@ -12,6 +12,7 @@ enum AlertType {
     case HMHQuitALert
     case HMHPushALert
     case Challenge
+    case delete
 }
 
 final class AlertViewController: UIViewController {
@@ -22,6 +23,7 @@ final class AlertViewController: UIViewController {
     private let quitAlert = HMHQuitAlert()
     private let pushAlert = HMHPushAlert()
     private let challengeAlert = ChallengeAlert()
+    private let deleteAlert = HMHDeleteAlert()
     
     var appName = ""
     
@@ -40,7 +42,7 @@ final class AlertViewController: UIViewController {
     }
     
     private func setHierarchy() {
-        view.addSubviews(logoutAlert, quitAlert, pushAlert, challengeAlert)
+        view.addSubviews(logoutAlert, quitAlert, pushAlert, challengeAlert, deleteAlert)
     }
     
     private func setConstraint() {
@@ -67,28 +69,37 @@ final class AlertViewController: UIViewController {
             $0.height.equalTo(344.adjusted)
             $0.width.equalTo(293.adjusted)
         }
+        
+        deleteAlert.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.height.equalTo(222.adjusted)
+            $0.width.equalTo(293.adjusted)
+        }
     }
     
     private func setAlertType() {
         switch alertType {
         case .HMHLogoutAlert:
-            setAlertView(logout: true, quit: false, push: false, challenge: false)
+            setAlertView(logout: true, quit: false, push: false, challenge: false, delete: false)
         case .HMHQuitALert:
-            setAlertView(logout: false, quit: true, push: false, challenge: false)
+            setAlertView(logout: false, quit: true, push: false, challenge: false, delete: false)
         case .HMHPushALert:
-            setAlertView(logout: false, quit: false, push: true, challenge: false)
+            setAlertView(logout: false, quit: false, push: true, challenge: false, delete: false)
         case .Challenge:
-            setAlertView(logout: false, quit: false, push: false, challenge: true)
+            setAlertView(logout: false, quit: false, push: false, challenge: true, delete: false)
+        case .delete:
+            setAlertView(logout: false, quit: false, push: false, challenge: false, delete: true)
         default:
             break
         }
     }
     
-    private func setAlertView(logout: Bool, quit: Bool, push: Bool, challenge: Bool) {
+    private func setAlertView(logout: Bool, quit: Bool, push: Bool, challenge: Bool, delete: Bool) {
         logoutAlert.isHidden = !logout
         quitAlert.isHidden = !quit
         pushAlert.isHidden = !push
         challengeAlert.isHidden = !challenge
+        deleteAlert.isHidden = !delete
     }
     
     func setDelegate() {
@@ -96,6 +107,7 @@ final class AlertViewController: UIViewController {
         quitAlert.delegate = self
         pushAlert.delegate = self
         challengeAlert.delegate = self
+        deleteAlert.delegate = self
     }
     
     func emptyActions() {

--- a/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/HMHDeleteAlert.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/HMHDeleteAlert.swift
@@ -1,8 +1,8 @@
 //
-//  HMHPushAlert.swift
+//  HMHDeleteAlert.swift
 //  HMH_iOS
 //
-//  Created by 지희의 MAC on 1/15/24.
+//  Created by Seonwoo Kim on 1/18/24.
 //
 
 import UIKit
@@ -10,7 +10,7 @@ import UIKit
 import SnapKit
 import Then
 
-final class HMHPushAlert: UIView {
+final class HMHDeleteAlert: UIView {
     weak var delegate: AlertDelegate?
     var appName: String = ""
     
@@ -22,11 +22,11 @@ final class HMHPushAlert: UIView {
     }
     
     private let descriptionLabel = UILabel().then {
-        $0.text = StringLiteral.AlertDescription.push
+        $0.text = StringLiteral.AlertDescription.delete
         $0.textColor = .whiteText
         $0.font = .iosDetail1Regular14
         $0.textAlignment = .center
-        $0.setTextWithLineHeight(text: StringLiteral.AlertDescription.push, lineHeight: 21)
+        $0.setTextWithLineHeight(text: StringLiteral.AlertDescription.delete, lineHeight: 21)
         $0.numberOfLines = .zero
     }
     
@@ -62,13 +62,13 @@ final class HMHPushAlert: UIView {
     
     private func setConstraints() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(35.adjusted)
+            $0.top.equalToSuperview().inset(33.adjusted)
             $0.horizontalEdges.equalToSuperview()
         }
         
         descriptionLabel.snp.makeConstraints {
-            $0.top.equalTo(titleLabel.snp.bottom).offset(12.adjusted)
-            $0.horizontalEdges.equalToSuperview().inset(44.adjusted)
+            $0.top.equalTo(titleLabel.snp.bottom).offset(10.adjusted)
+            $0.centerX.equalToSuperview()
         }
         
         buttonStackView.snp.makeConstraints {
@@ -90,7 +90,7 @@ final class HMHPushAlert: UIView {
     }
     
     func setAppName(appName: String) {
-        self.titleLabel.text = appName + StringLiteral.AlertTitle.push
+        self.titleLabel.text = appName + StringLiteral.AlertTitle.delete
     }
     
     @objc func cancelButtonTapped() {
@@ -98,7 +98,7 @@ final class HMHPushAlert: UIView {
     }
     
     @objc func confirmButtonTapped() {
-        //여기서 연장 / 실패 서버통신
         delegate?.alertDismissTapped()
     }
 }
+

--- a/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/HMHDeleteAlert.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/HMHDeleteAlert.swift
@@ -79,8 +79,8 @@ final class HMHDeleteAlert: UIView {
     }
     
     private func setAddTarget() {
-        cancelButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
-        confirmButton.addTarget(self, action: #selector(confirmButtonTapped), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(deleteButtonTapped), for: .touchUpInside)
+        confirmButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
     }
     
     private func configureView() {
@@ -98,8 +98,8 @@ final class HMHDeleteAlert: UIView {
         delegate?.alertDismissTapped()
     }
     
-    @objc func confirmButtonTapped() {
-        delegate?.alertDismissTapped()
+    @objc func deleteButtonTapped() {
+        delegate?.deleteButtonTapped()
     }
 }
 

--- a/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/HMHDeleteAlert.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/HMHDeleteAlert.swift
@@ -19,6 +19,7 @@ final class HMHDeleteAlert: UIView {
         $0.font = .iosText5Medium16
         $0.textAlignment = .center
         $0.numberOfLines = 2
+        $0.text = "정말 인스타그램" + StringLiteral.AlertTitle.delete
     }
     
     private let descriptionLabel = UILabel().then {
@@ -62,10 +63,10 @@ final class HMHDeleteAlert: UIView {
     
     private func setConstraints() {
         titleLabel.snp.makeConstraints {
-            $0.top.equalToSuperview().inset(33.adjusted)
+            $0.top.equalToSuperview().inset(35.adjusted)
             $0.horizontalEdges.equalToSuperview()
         }
-        
+
         descriptionLabel.snp.makeConstraints {
             $0.top.equalTo(titleLabel.snp.bottom).offset(10.adjusted)
             $0.centerX.equalToSuperview()

--- a/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/HMHLogoutAlert.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/HMHLogoutAlert.swift
@@ -26,8 +26,8 @@ final class HMHLogoutAlert: UIView {
         $0.spacing = 7
     }
     
-    private let cancelButton = CustomAlertButton(buttonType: .disabled, buttonText: StringLiteral.AlertButton.close)
-    private let confirmButton = CustomAlertButton(buttonType: .enabled, buttonText: StringLiteral.AlertButton.confirm)
+    private let confrimButton = CustomAlertButton(buttonType: .disabled, buttonText: StringLiteral.AlertButton.confirm)
+    private let cancelButton = CustomAlertButton(buttonType: .enabled, buttonText: StringLiteral.AlertButton.cancel)
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -46,7 +46,7 @@ final class HMHLogoutAlert: UIView {
     
     private func setHierarchy() {
         self.addSubviews(titleLabel, buttonStackView)
-        buttonStackView.addArrangeSubViews([cancelButton, confirmButton])
+        buttonStackView.addArrangeSubViews([confrimButton, cancelButton])
     }
     
     private func setConstraints() {
@@ -62,8 +62,8 @@ final class HMHLogoutAlert: UIView {
     }
     
     private func setAddTarget() {
-        cancelButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
-        confirmButton.addTarget(self, action: #selector(confirmButtonTapped), for: .touchUpInside)
+        confrimButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(confirmButtonTapped), for: .touchUpInside)
     }
     
     private func configureView() {
@@ -74,10 +74,10 @@ final class HMHLogoutAlert: UIView {
     }
     
     @objc func cancelButtonTapped() {
-        delegate?.alertDismissTapped()
+        delegate?.enabledButtonTapped()
     }
     
     @objc func confirmButtonTapped() {
-        delegate?.enabledButtonTapped()
+        delegate?.alertDismissTapped()
     }
 }

--- a/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/HMHQuitAlert.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/HMHQuitAlert.swift
@@ -35,8 +35,8 @@ final class HMHQuitAlert: UIView {
         $0.spacing = 7
     }
     
-    private let cancelButton = CustomAlertButton(buttonType: .disabled, buttonText: StringLiteral.AlertButton.quit)
-    private let confirmButton = CustomAlertButton(buttonType: .enabled, buttonText: StringLiteral.AlertButton.confirm)
+    private let quitButton = CustomAlertButton(buttonType: .disabled, buttonText: StringLiteral.AlertButton.quit)
+    private let cancelButton = CustomAlertButton(buttonType: .enabled, buttonText: StringLiteral.AlertButton.cancel)
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -55,7 +55,7 @@ final class HMHQuitAlert: UIView {
     
     private func setHierarchy() {
         self.addSubviews(titleLabel, descriptionLabel, buttonStackView)
-        buttonStackView.addArrangeSubViews([cancelButton, confirmButton])
+        buttonStackView.addArrangeSubViews([quitButton, cancelButton])
     }
     
     private func setConstraints() {
@@ -76,8 +76,8 @@ final class HMHQuitAlert: UIView {
     }
     
     private func setAddTarget() {
-        cancelButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
-        confirmButton.addTarget(self, action: #selector(confirmButtonTapped), for: .touchUpInside)
+        quitButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(confirmButtonTapped), for: .touchUpInside)
     }
     
     private func configureView() {
@@ -88,10 +88,10 @@ final class HMHQuitAlert: UIView {
     }
     
     @objc func cancelButtonTapped() {
-        delegate?.alertDismissTapped()
+        delegate?.enabledButtonTapped()
     }
     
     @objc func confirmButtonTapped() {
-        delegate?.enabledButtonTapped()
+        delegate?.alertDismissTapped()
     }
 }

--- a/HMH_iOS/HMH_iOS/Presentation/CreateChallenge/ViewControllers/CreateTotalTimeController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/CreateChallenge/ViewControllers/CreateTotalTimeController.swift
@@ -74,8 +74,9 @@ final class CreateTotalTimeController: OnboardingBaseViewController {
 
 extension CreateTotalTimeController: NextViewPushDelegate {
     func didTapButton() {
+        SignUpManager.shared.goalTime = totalTime
         let provider = Providers.challengeProvider
-        let challenge = CreateChallengeRequestDTO(period: SignUpManager.shared.period, goalTime:  SignUpManager.shared.goalTime)
+        let challenge = CreateChallengeRequestDTO(period: SignUpManager.shared.period, goalTime: SignUpManager.shared.goalTime)
         provider.request(target: .createChallenge(data: challenge), instance: BaseResponse<CreateChallengeResponseDTO>.self, viewController: self) { data in
             self.isCreated = true
         }
@@ -90,6 +91,6 @@ extension CreateTotalTimeController: NextViewPushDelegate {
 extension CreateTotalTimeController: TimePickerDelegate {
     func updateAvailability(selectedValue: Int, type: HMHTimePickerView.TimePickerType) {
         nextButton.updateStatus(isEnabled: true)
-        totalTime = selectedValue
+        totalTime = convertHoursAndMinutesToMilliseconds(hours: selectedValue, minutes: 0)
     }
 }

--- a/HMH_iOS/HMH_iOS/Presentation/CreateChallenge/Views/HMHTimePickerView.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/CreateChallenge/Views/HMHTimePickerView.swift
@@ -44,7 +44,7 @@ final class HMHTimePickerView: UIPickerView {
     private func configureList() {
         switch type {
         case .totalTime:
-            timeList = ["1", "2", "3", "4", "5", "6"]
+            timeList = ["2", "3", "4", "5", "6"]
             
         case .specificTime:
             timeList = ["0", "1"]


### PR DESCRIPTION
## 👾 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- AlertViewController에 deleteAlert에 관한 case를 추가하여 커스텀으로 사용할 수 있게 하였습니다. 
- 1-6 시간으로 기존 총 시간을 설정할 수 있었던 부분에서, 2-6 시간으로 바꾸었습니다.
- AlertDelegate로 DeleteAlert의 확인 버튼을 누르면 해당 함수가 실행되게 하였습니다.
```swift
    func deleteButtonTapped() {
        let challengeController = ChallengeViewController()
        challengeController.deleteTap()
        dismiss(animated: false) {
            (self.okAction ?? self.emptyActions)()
        }
    }
```
- 챌린지 컨트롤러의 deleteTap함수를 실행시키고, alert창이 dismiss 됩니다.
- deleteTap함수의 구현부는 일단 print문으로 찍히는 것 까지만 구현했습니다.
- API 연결 부와 합쳐서 delete를 누르면 특정 앱 삭제에 대한 동작과 cell을 리로드 시켜주는 부분이 있으면 될 것 같습니다.

## 🚀 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 강조하고 싶은 내용 등을 적어주세요! -->
- 데이터를 어떻게 뿌릴지 공유 부탁드릴게요!

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 화면종류 | ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/83943a6c-b606-4026-a56b-f607688633c8) |

## 🚀 기기 대응
|    기기명    |   Iphone 13 mini  | Iphone 15 pro| Iphone 14| Iphone SE(3rd) |
| :-------------: | :----------: | :----------: | :----------: |:----------: |
| 스크린샷 | | ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/8f48f608-ba4c-44cf-9a80-5ace43174c25)| ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/9070a145-355a-4ec5-8b87-06936c545241)|  | ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/8f48f608-ba4c-44cf-9a80-5ace43174c25)| ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/9070a145-355a-4ec5-8b87-06936c545241)|  ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/87d0cdce-8b8d-4b64-bf7b-9c2aceded767)|  ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/8f48f608-ba4c-44cf-9a80-5ace43174c25)| ![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/2f91fc74-c0f7-4af4-8a8f-e6314f4fc2ff)|  

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #108 
