### PR TITLE
[Feat/#110] Alert - 삭제 API 적용

### DIFF
--- a/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/AlertViewController.swift
+++ b/HMH_iOS/HMH_iOS/Presentation/Common/CustomAlert/AlertViewController.swift
@@ -108,6 +108,18 @@ final class AlertViewController: UIViewController {
 }
 
 extension AlertViewController: AlertDelegate {
+    func deleteButtonTapped() {
+        let provider = Providers.challengeProvider
+        let data = DeleteAppRequestDTO(appCode: "#25350")
+        provider.request(target: .deleteApp(data: data), instance: BaseResponse<EmptyResponseDTO>.self, viewController: self) { data in
+        }
+        
+        let challengeController = ChallengeViewController()
+        challengeController.deleteTap()
+        dismiss(animated: false) {
+            (self.okAction ?? self.emptyActions)()
+        }
+    }
     func confirmButtonTapped() {
         setRootViewController(TabBarController())
     }


### PR DESCRIPTION
## 👾 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 삭제 alert에서 확인을 눌렀을 때 API가 작동하여 해당 appcode가 삭제 되게 구현하였습니다.

## 📸 스크린샷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    구현 내용    |   스크린샷   |
| :-------------: | :----------: |
| 화면종류 | 
![image](https://github.com/Team-HMH/HMH-iOS/assets/95562494/073db0bc-bbde-4654-8a3c-d39fec63cc9e)|


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #110 
